### PR TITLE
docs: rewrite README with room-based quick-start guide and module categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,46 +2,82 @@
 
 [![FlakeHub](https://img.shields.io/endpoint?url=https://flakehub.com/f/nixcafe/cattery-modules/badge)](https://flakehub.com/flake/nixcafe/cattery-modules)
 
-Nix modules for system and home-manager configuration.
+A curated collection of Nix modules for **quick-starting NixOS, nix-darwin, and home-manager** configurations. Choose a room, enable it, and get a complete system — no boilerplate.
 
-## Usage
+## Quick Start
 
 ```nix
+# flake.nix
 {
   inputs.cattery-modules.url = "https://flakehub.com/f/nixcafe/cattery-modules/*.tar.gz";
 
-  outputs = { self, cattery-modules, ... }: {
-    # Use in your outputs
+  outputs = { self, nixpkgs, cattery-modules, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [ cattery-modules.nixosModules.default ];
+    };
   };
 }
 ```
 
-## Contributing
+```nix
+# configuration.nix
+{ config, ... }: {
+  # One room = a fully configured dev desktop
+  cattery.room.desktop.dev.enable = true;
+}
+```
 
-This project follows **GitHub Flow**:
+## Rooms
 
-1. Create a feature branch from `main`:
-   ```
-   feat/some-feature
-   fix/some-bug
-   chore/some-cleanup
-   ```
-2. Make your changes and test locally (`nixos-rebuild test` / `home-manager switch`)
-3. Run `nix flake check` and `nix fmt`
-4. Open a pull request against `main`
-5. Wait for CI to pass and at least one review approval
+Rooms are **pre-configured module bundles** — enable one room and get dozens of modules configured with sensible defaults. Each room includes and extends the one below it.
 
-### Branch naming
+| Room | Description | Includes |
+| --- | --- | --- |
+| `room.basis` | Base system (nix, git, openssh, locale, fonts) | — |
+| `room.general` | General additions (shell, CLI tools, editors) | basis |
+| `room.desktop.basis` | Desktop base (display, compositor, theming) | general |
+| `room.desktop.general` | Full desktop (apps, services, audio, input) | desktop.basis |
+| `room.desktop.dev` | Developer desktop (IDEs, databases, containers) | desktop.general |
+| `room.desktop.game` | Gaming desktop (Steam, GPU drivers, Wine) | desktop.general |
+| `room.desktop.wsl` | WSL desktop | desktop.basis |
+| `room.server-mini` | Lightweight server | basis |
+| `room.server` | Full server (docker, nginx, postgres, forgejo) | server-mini |
+| `room.container` | Container host (incus, distrobox) | basis |
 
-| Prefix   | Purpose          |
-| -------- | ---------------- |
-| `feat/`  | New features     |
-| `fix/`   | Bug fixes        |
-| `chore/` | Maintenance      |
-| `docs/`  | Documentation    |
+> Rooms are available for NixOS, home-manager, and nix-darwin. Each room automatically enables its dependency chain — enable `desktop.dev` and you get all of `basis → general → desktop.basis → desktop.general → desktop.dev`.
 
-### Development
+## Using Individual Modules
+
+You can also enable modules individually:
+
+```nix
+cattery.themes.catppuccin.enable = true;
+cattery.desktop.hyprland.enable = true;
+cattery.services.tailscale.enable = true;
+```
+
+## Module Categories
+
+| Category | Highlights |
+| --- | --- |
+| **Theming** | Catppuccin (GTK, Qt, Plasma, Hyprland), SDDM themes |
+| **Desktop** | Hyprland, Niri, GNOME, KDE Plasma |
+| **Gaming** | Steam, GPU drivers (AMD/NVIDIA), RetroArch |
+| **Security** | agenix secrets, impermanence (ephemeral root), Secure Boot (lanzaboote) |
+| **Services** | nginx, PostgreSQL, Forgejo, Tailscale, Vaultwarden, Docker |
+| **Dev** | VS Code Server, JetBrains, dev-kit (git, nix, shell tools) |
+| **Platform** | NixOS-WSL, nix-darwin, Proxmox LXC |
+
+## Development
 
 ```bash
-nix develop  # enter dev shell with formatters and pre-commit hooks
+nix develop     # enter dev shell with nixfmt, deadnix, statix
+nix flake check # lint + eval all modules
+nix fmt         # format all files
 ```
+
+This project follows [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow). Branch prefix: `feat/`, `fix/`, `chore/`, `docs/`. All PRs require one approving review and passing CI.
+
+## License
+
+[CC0 1.0 Universal](LICENSE)


### PR DESCRIPTION
## Summary

Rewrite the README to highlight the room concept:

- Quick start example (`cattery.room.desktop.dev.enable = true;`)
- Room dependency chain table
- Module category overview
- Cleaned up development section