### PR TITLE
fix: update lib references to purr directory-based structure

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -331,11 +331,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784129366,
-        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
+        "lastModified": 1784351324,
+        "narHash": "sha256-By+kuRJZRqs2TuXgtR8vJ8cTKWXw33YG/Yollu5cO1U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
+        "rev": "460108009ca1ff69ca2ff19079ca2c838d6e3080",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784258098,
-        "narHash": "sha256-tgRJ/WwNnZbmuEqaJET+xPmAt2hBK5kEutNM4k6RUko=",
+        "lastModified": 1784343184,
+        "narHash": "sha256-xD2Fxgh6jD0m3v3ijO9+59EFlYIwIlnw8Z/yQpsAukA=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "79a2e20b272c80cdff340656399369e99f55c526",
+        "rev": "ddadbf248cacdd057658d30bd079e589e7c2b750",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1784315558,
-        "narHash": "sha256-0QpTqh3aRApdN27hdWgS9k0+5/jD2Ets8HRBALq0fzM=",
+        "lastModified": 1784355775,
+        "narHash": "sha256-EYWkeWfSA1sbamKkMzN5frPUkKpQ9F1xiFaojdlO1sM=",
         "owner": "nixcafe",
         "repo": "purr",
-        "rev": "98dde42e51c547ba02cff230aadfd028e73fc831",
+        "rev": "06b35d201aae8c714326479fc92aa8889088e04c",
         "type": "github"
       },
       "original": {
@@ -700,11 +700,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784265529,
-        "narHash": "sha256-ohQQiPOngux8ofsrSlloHCMDhRMvocXqJiG8uH45Q5k=",
+        "lastModified": 1784350408,
+        "narHash": "sha256-OstzLWL5t7Xe14xEC6GIMJCp0PrYNTSA0El7GG2av88=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "068175006cfb69d5b541a140ed93e361488c9e53",
+        "rev": "3c38e1e1ba9c8d7030f7b5a801398ea7d8a6fdc0",
         "type": "github"
       },
       "original": {

--- a/lib/module/default.nix
+++ b/lib/module/default.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, ... }:
 let
   inherit (lib) mkDefault;
 in

--- a/lib/secrets/default.nix
+++ b/lib/secrets/default.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, ... }:
 let
   inherit (lib)
     types
@@ -9,63 +9,226 @@ let
     concatMapAttrs
     ;
 in
-{
-  secrets = rec {
-    scopeList = [
-      "hosts-global"
-      "hosts-user"
-      "shared-global"
-      "shared-user"
-    ];
+rec {
+  scopeList = [
+    "hosts-global"
+    "hosts-user"
+    "shared-global"
+    "shared-user"
+  ];
 
-    getSecretPrefix =
-      scope: host: user:
-      if scope == "hosts-global" then
-        "hosts/${host}/global"
-      else if scope == "hosts-user" then
-        "hosts/${host}/users/${user}"
-      else if scope == "shared-global" then
-        "shared/global"
-      else if scope == "shared-user" then
-        "shared/users/${user}"
-      else
-        "";
+  getSecretPrefix =
+    scope: host: user:
+    if scope == "hosts-global" then
+      "hosts/${host}/global"
+    else if scope == "hosts-user" then
+      "hosts/${host}/users/${user}"
+    else if scope == "shared-global" then
+      "shared/global"
+    else if scope == "shared-user" then
+      "shared/users/${user}"
+    else
+      "";
 
-    mkMappingOption =
+  mkMappingOption =
+    {
+      fileName,
+      source,
+      buildTarget ? (source: source),
+      owner ? "root",
+      group ? owner,
+      mode ? "0400", # Read-only
+      description ? "",
+      ...
+    }:
+    types.submodule (
+      { name, config, ... }:
       {
-        fileName,
-        source,
-        buildTarget ? (source: source),
-        owner ? "root",
-        group ? owner,
-        mode ? "0400", # Read-only
-        description ? "",
-        ...
-      }:
-      types.submodule (
-        { name, config, ... }:
+        options = {
+          name = mkOption {
+            type = types.str;
+            default = name;
+            readOnly = true;
+          };
+          fileName = mkOption {
+            type = types.str;
+            default = fileName;
+          };
+          source = mkOption {
+            type = types.str;
+            default = source;
+            inherit description;
+          };
+          target = mkOption {
+            type = types.str;
+            default = buildTarget config.source;
+            readOnly = true;
+            inherit description;
+          };
+          mode = mkOption {
+            type = types.str;
+            default = mode;
+          };
+          owner = mkOption {
+            type = types.str;
+            default = owner;
+            description = "The owner of the files.";
+          };
+          group = mkOption {
+            type = types.str;
+            default = group;
+            description = "The group of the files.";
+          };
+        };
+      }
+    );
+
+  mkHomeMappingOption =
+    {
+      fileName,
+      source,
+      buildTarget ? (source: source),
+      mode ? "0400", # Read-only
+      description ? "",
+      ...
+    }:
+    types.submodule (
+      { name, config, ... }:
+      {
+        options = {
+          name = mkOption {
+            type = types.str;
+            default = name;
+            readOnly = true;
+          };
+          fileName = mkOption {
+            type = types.str;
+            default = fileName;
+          };
+          source = mkOption {
+            type = types.str;
+            default = source;
+            inherit description;
+          };
+          target = mkOption {
+            type = types.str;
+            default = buildTarget config.source;
+            readOnly = true;
+            inherit description;
+          };
+          mode = mkOption {
+            type = types.str;
+            default = mode;
+          };
+        };
+      }
+    );
+
+  mkAppSecretsOption =
+    {
+      enable ? true,
+      appName,
+      dirPath ? appName,
+      configNames ? [ ],
+      fixedConfig ? [ ],
+      scope ? "hosts-global",
+      currentInfo,
+      buildTargetPath ? (sourcePath: sourcePath),
+      owner ? "root",
+      group ? owner,
+      mode ? "0400", # Read-only
+      ...
+    }:
+    mkOption {
+      type = types.submodule (
+        { config, ... }:
         {
           options = {
-            name = mkOption {
-              type = types.str;
-              default = name;
+            enable = mkEnableOption "enable ${appName} secrets" // {
+              default = enable;
+            };
+            etc = {
+              enable = mkEnableOption "bind to etc" // {
+                default = true;
+              };
+              useSymlink = mkEnableOption "use symlink to etc" // {
+                default = true;
+              };
+              dirPath = mkOption {
+                type = types.str;
+                default = dirPath;
+                description = ''
+                  relative to the path of etc.
+                  Just like: `/etc/{etc.dirPath}`
+                '';
+              };
+              files = mkOption {
+                type = types.attrs;
+                default = concatMapAttrs (_: item: {
+                  "${config.etc.dirPath}/${item.fileName}" = {
+                    source = item.target;
+                  }
+                  // (optionalAttrs (!config.etc.useSymlink) {
+                    inherit (item) mode group;
+                    user = owner;
+                  });
+                }) config.files;
+                readOnly = true;
+              };
+            };
+            scope = mkOption {
+              type = types.enum scopeList;
+              default = scope;
+            };
+            secretMappingFiles = mkOption {
+              type = types.attrs;
+              default =
+                let
+                  user = currentInfo.user or "root";
+                  files = concatMapAttrs (_: item: {
+                    "${item.source}" = {
+                      inherit (item) mode owner group;
+                    };
+                  }) config.files;
+                in
+                if scope == "hosts-global" then
+                  { hosts.global.files = files; }
+                else if scope == "hosts-user" then
+                  { hosts.users.${user}.files = files; }
+                else if scope == "shared-global" then
+                  { shared.global.files = files; }
+                else if scope == "shared-user" then
+                  { shared.users.${user}.files = files; }
+                else
+                  { };
               readOnly = true;
+              internal = true;
+              visible = false;
             };
-            fileName = mkOption {
-              type = types.str;
-              default = fileName;
+            configNames = mkOption {
+              type = types.listOf types.str;
+              default = configNames;
             };
-            source = mkOption {
-              type = types.str;
-              default = source;
-              inherit description;
-            };
-            target = mkOption {
-              type = types.str;
-              default = buildTarget config.source;
-              readOnly = true;
-              inherit description;
-            };
+            files = foldl' (
+              acc: item:
+              acc
+              // {
+                ${item.name} = mkOption {
+                  type = mkMappingOption {
+                    inherit (config) owner group mode;
+                    fileName = item.fileName or item.name;
+                    source = "${dirPath}/${item.fileName or item.name}";
+                    buildTarget =
+                      source:
+                      (buildTargetPath "${
+                        getSecretPrefix config.scope (currentInfo.host or "localhost") (currentInfo.user or "root")
+                      }/${source}");
+                    description = item.description or "The ${item.name} configuration file.";
+                  };
+                  default = { };
+                };
+              }
+            ) { } (fixedConfig ++ (map (name: { inherit name; }) config.configNames));
             mode = mkOption {
               type = types.str;
               default = mode;
@@ -83,40 +246,82 @@ in
           };
         }
       );
+      default = { };
+    };
 
-    mkHomeMappingOption =
-      {
-        fileName,
-        source,
-        buildTarget ? (source: source),
-        mode ? "0400", # Read-only
-        description ? "",
-        ...
-      }:
-      types.submodule (
-        { name, config, ... }:
+  mkHomeAppSecretsOption =
+    {
+      enable ? true,
+      appName,
+      dirPath ? appName,
+      configNames ? [ ],
+      fixedConfig ? [ ],
+      scope ? "hosts-user",
+      currentInfo,
+      buildTargetPath ? (sourcePath: sourcePath),
+      mode ? "0400", # Read-only
+      ...
+    }:
+    mkOption {
+      type = types.submodule (
+        { config, ... }:
         {
           options = {
-            name = mkOption {
-              type = types.str;
-              default = name;
+            enable = mkEnableOption "enable ${appName} secrets" // {
+              default = enable;
+            };
+            scope = mkOption {
+              type = types.enum scopeList;
+              default = scope;
+            };
+            secretMappingFiles = mkOption {
+              type = types.attrs;
+              default =
+                let
+                  user = currentInfo.user or "root";
+                  files = concatMapAttrs (_: item: {
+                    "${item.source}" = {
+                      inherit (item) mode;
+                    };
+                  }) config.files;
+                in
+                if scope == "hosts-global" then
+                  { hosts.global.files = files; }
+                else if scope == "hosts-user" then
+                  { hosts.users.${user}.files = files; }
+                else if scope == "shared-global" then
+                  { shared.global.files = files; }
+                else if scope == "shared-user" then
+                  { shared.users.${user}.files = files; }
+                else
+                  { };
               readOnly = true;
+              visible = false;
             };
-            fileName = mkOption {
-              type = types.str;
-              default = fileName;
+            configNames = mkOption {
+              type = types.listOf types.str;
+              default = configNames;
             };
-            source = mkOption {
-              type = types.str;
-              default = source;
-              inherit description;
-            };
-            target = mkOption {
-              type = types.str;
-              default = buildTarget config.source;
-              readOnly = true;
-              inherit description;
-            };
+            files = foldl' (
+              acc: item:
+              acc
+              // {
+                ${item.name} = mkOption {
+                  type = mkHomeMappingOption {
+                    inherit (config) mode;
+                    fileName = item.fileName or item.name;
+                    source = "${dirPath}/${item.fileName or item.name}";
+                    buildTarget =
+                      source:
+                      (buildTargetPath "${
+                        getSecretPrefix config.scope (currentInfo.host or "localhost") (currentInfo.user or "root")
+                      }/${source}");
+                    description = item.description or "The ${item.name} configuration file.";
+                  };
+                  default = { };
+                };
+              }
+            ) { } (fixedConfig ++ (map (name: { inherit name; }) config.configNames));
             mode = mkOption {
               type = types.str;
               default = mode;
@@ -124,213 +329,6 @@ in
           };
         }
       );
-
-    mkAppSecretsOption =
-      {
-        enable ? true,
-        appName,
-        dirPath ? appName,
-        configNames ? [ ],
-        fixedConfig ? [ ],
-        scope ? "hosts-global",
-        currentInfo,
-        buildTargetPath ? (sourcePath: sourcePath),
-        owner ? "root",
-        group ? owner,
-        mode ? "0400", # Read-only
-        ...
-      }:
-      mkOption {
-        type = types.submodule (
-          { config, ... }:
-          {
-            options = {
-              enable = mkEnableOption "enable ${appName} secrets" // {
-                default = enable;
-              };
-              etc = {
-                enable = mkEnableOption "bind to etc" // {
-                  default = true;
-                };
-                useSymlink = mkEnableOption "use symlink to etc" // {
-                  default = true;
-                };
-                dirPath = mkOption {
-                  type = types.str;
-                  default = dirPath;
-                  description = ''
-                    relative to the path of etc.
-                    Just like: `/etc/{etc.dirPath}`
-                  '';
-                };
-                files = mkOption {
-                  type = types.attrs;
-                  default = concatMapAttrs (_: item: {
-                    "${config.etc.dirPath}/${item.fileName}" = {
-                      source = item.target;
-                    }
-                    // (optionalAttrs (!config.etc.useSymlink) {
-                      inherit (item) mode group;
-                      user = owner;
-                    });
-                  }) config.files;
-                  readOnly = true;
-                };
-              };
-              scope = mkOption {
-                type = types.enum scopeList;
-                default = scope;
-              };
-              secretMappingFiles = mkOption {
-                type = types.attrs;
-                default =
-                  let
-                    user = currentInfo.user or "root";
-                    files = concatMapAttrs (_: item: {
-                      "${item.source}" = {
-                        inherit (item) mode owner group;
-                      };
-                    }) config.files;
-                  in
-                  if scope == "hosts-global" then
-                    { hosts.global.files = files; }
-                  else if scope == "hosts-user" then
-                    { hosts.users.${user}.files = files; }
-                  else if scope == "shared-global" then
-                    { shared.global.files = files; }
-                  else if scope == "shared-user" then
-                    { shared.users.${user}.files = files; }
-                  else
-                    { };
-                readOnly = true;
-                internal = true;
-                visible = false;
-              };
-              configNames = mkOption {
-                type = types.listOf types.str;
-                default = configNames;
-              };
-              files = foldl' (
-                acc: item:
-                acc
-                // {
-                  ${item.name} = mkOption {
-                    type = mkMappingOption {
-                      inherit (config) owner group mode;
-                      fileName = item.fileName or item.name;
-                      source = "${dirPath}/${item.fileName or item.name}";
-                      buildTarget =
-                        source:
-                        (buildTargetPath "${
-                          getSecretPrefix config.scope (currentInfo.host or "localhost") (currentInfo.user or "root")
-                        }/${source}");
-                      description = item.description or "The ${item.name} configuration file.";
-                    };
-                    default = { };
-                  };
-                }
-              ) { } (fixedConfig ++ (map (name: { inherit name; }) config.configNames));
-              mode = mkOption {
-                type = types.str;
-                default = mode;
-              };
-              owner = mkOption {
-                type = types.str;
-                default = owner;
-                description = "The owner of the files.";
-              };
-              group = mkOption {
-                type = types.str;
-                default = group;
-                description = "The group of the files.";
-              };
-            };
-          }
-        );
-        default = { };
-      };
-
-    mkHomeAppSecretsOption =
-      {
-        enable ? true,
-        appName,
-        dirPath ? appName,
-        configNames ? [ ],
-        fixedConfig ? [ ],
-        scope ? "hosts-user",
-        currentInfo,
-        buildTargetPath ? (sourcePath: sourcePath),
-        mode ? "0400", # Read-only
-        ...
-      }:
-      mkOption {
-        type = types.submodule (
-          { config, ... }:
-          {
-            options = {
-              enable = mkEnableOption "enable ${appName} secrets" // {
-                default = enable;
-              };
-              scope = mkOption {
-                type = types.enum scopeList;
-                default = scope;
-              };
-              secretMappingFiles = mkOption {
-                type = types.attrs;
-                default =
-                  let
-                    user = currentInfo.user or "root";
-                    files = concatMapAttrs (_: item: {
-                      "${item.source}" = {
-                        inherit (item) mode;
-                      };
-                    }) config.files;
-                  in
-                  if scope == "hosts-global" then
-                    { hosts.global.files = files; }
-                  else if scope == "hosts-user" then
-                    { hosts.users.${user}.files = files; }
-                  else if scope == "shared-global" then
-                    { shared.global.files = files; }
-                  else if scope == "shared-user" then
-                    { shared.users.${user}.files = files; }
-                  else
-                    { };
-                readOnly = true;
-                visible = false;
-              };
-              configNames = mkOption {
-                type = types.listOf types.str;
-                default = configNames;
-              };
-              files = foldl' (
-                acc: item:
-                acc
-                // {
-                  ${item.name} = mkOption {
-                    type = mkHomeMappingOption {
-                      inherit (config) mode;
-                      fileName = item.fileName or item.name;
-                      source = "${dirPath}/${item.fileName or item.name}";
-                      buildTarget =
-                        source:
-                        (buildTargetPath "${
-                          getSecretPrefix config.scope (currentInfo.host or "localhost") (currentInfo.user or "root")
-                        }/${source}");
-                      description = item.description or "The ${item.name} configuration file.";
-                    };
-                    default = { };
-                  };
-                }
-              ) { } (fixedConfig ++ (map (name: { inherit name; }) config.configNames));
-              mode = mkOption {
-                type = types.str;
-                default = mode;
-              };
-            };
-          }
-        );
-        default = { };
-      };
-  };
+      default = { };
+    };
 }

--- a/lib/utils/default.nix
+++ b/lib/utils/default.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, ... }:
 let
   inherit (lib)
     splitString

--- a/modules/darwin/room/basis/default.nix
+++ b/modules/darwin/room/basis/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.basis;
 in

--- a/modules/darwin/room/desktop/dev/default.nix
+++ b/modules/darwin/room/desktop/dev/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.dev;
 in

--- a/modules/home/nixos/desktop/hyprland/theme/caelestia/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/caelestia/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) mkOption types mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.desktop.hyprland.theme.caelestia;

--- a/modules/home/nixos/desktop/hyprland/theme/caelestia/screenshots/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/caelestia/screenshots/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.desktop.hyprland.theme.caelestia.screenshots;

--- a/modules/home/nixos/desktop/hyprland/theme/charm-cat/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/charm-cat/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.desktop.hyprland.theme.charm-cat;

--- a/modules/home/nixos/desktop/hyprland/theme/charm-cat/lock-screen/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/charm-cat/lock-screen/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.desktop.hyprland.theme.charm-cat.lock-screen;

--- a/modules/home/nixos/desktop/hyprland/theme/charm-cat/screenshots/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/charm-cat/screenshots/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.desktop.hyprland.theme.charm-cat.screenshots;

--- a/modules/home/room/basis/default.nix
+++ b/modules/home/room/basis/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.basis;
 in

--- a/modules/home/room/container/default.nix
+++ b/modules/home/room/container/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.container;
 in

--- a/modules/home/room/desktop/basis/default.nix
+++ b/modules/home/room/desktop/basis/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.basis;
 in

--- a/modules/home/room/desktop/dev/default.nix
+++ b/modules/home/room/desktop/dev/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.dev;
 in

--- a/modules/home/room/desktop/game/default.nix
+++ b/modules/home/room/desktop/game/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.game;
 in

--- a/modules/home/room/desktop/general/default.nix
+++ b/modules/home/room/desktop/general/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.general;
 in

--- a/modules/home/room/desktop/wsl/default.nix
+++ b/modules/home/room/desktop/wsl/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.wsl;
 in

--- a/modules/home/room/game/default.nix
+++ b/modules/home/room/game/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.game;
 in

--- a/modules/home/room/general/default.nix
+++ b/modules/home/room/general/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.general;
 in

--- a/modules/home/room/server-mini/default.nix
+++ b/modules/home/room/server-mini/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.server;
 in

--- a/modules/home/room/server/default.nix
+++ b/modules/home/room/server/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.server;
 in

--- a/modules/nixos/desktop/gnome/default.nix
+++ b/modules/nixos/desktop/gnome/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.desktop.gnome;
 in

--- a/modules/nixos/desktop/hyprland/default.nix
+++ b/modules/nixos/desktop/hyprland/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.desktop.hyprland;
 in

--- a/modules/nixos/desktop/lightdm/default.nix
+++ b/modules/nixos/desktop/lightdm/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.desktop.lightdm;
 in

--- a/modules/nixos/desktop/niri/default.nix
+++ b/modules/nixos/desktop/niri/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.desktop.niri;
 in

--- a/modules/nixos/desktop/plasma/default.nix
+++ b/modules/nixos/desktop/plasma/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.desktop.plasma;
 in

--- a/modules/nixos/room/basis/default.nix
+++ b/modules/nixos/room/basis/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.basis;
 in

--- a/modules/nixos/room/container/default.nix
+++ b/modules/nixos/room/container/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.container;
 in

--- a/modules/nixos/room/desktop/basis/default.nix
+++ b/modules/nixos/room/desktop/basis/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.basis;
 in

--- a/modules/nixos/room/desktop/dev/default.nix
+++ b/modules/nixos/room/desktop/dev/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.dev;
 in

--- a/modules/nixos/room/desktop/game/default.nix
+++ b/modules/nixos/room/desktop/game/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.game;
 in

--- a/modules/nixos/room/desktop/general/default.nix
+++ b/modules/nixos/room/desktop/general/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.general;
 in

--- a/modules/nixos/room/desktop/wsl/default.nix
+++ b/modules/nixos/room/desktop/wsl/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.desktop.wsl;
 in

--- a/modules/nixos/room/general/default.nix
+++ b/modules/nixos/room/general/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.general;
 in

--- a/modules/nixos/room/server-mini/default.nix
+++ b/modules/nixos/room/server-mini/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.server-mini;
 in

--- a/modules/nixos/room/server/default.nix
+++ b/modules/nixos/room/server/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib) mkDefault;
-  inherit (lib.${namespace}) mkDefaultEnabled;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
 
   cfg = config.${namespace}.room.server;
 in

--- a/modules/nixos/services/acme/default.nix
+++ b/modules/nixos/services/acme/default.nix
@@ -11,7 +11,7 @@ let
     concatMapAttrs
     optional
     ;
-  inherit (lib.${namespace}) getRootDomain;
+  inherit (lib.${namespace}.utils) getRootDomain;
   inherit (config.${namespace}) user;
   inherit (config.${namespace}.services) nginx;
 

--- a/modules/nixos/services/acme/secrets/default.nix
+++ b/modules/nixos/services/acme/secrets/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) optionalString unique foldl';
-  inherit (lib.${namespace}) getRootDomain;
+  inherit (lib.${namespace}.utils) getRootDomain;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
+++ b/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) mkOption types;
-  inherit (lib.${namespace}) escapeSystemdPath;
+  inherit (lib.${namespace}.utils) escapeSystemdPath;
 
   cfg = config.${namespace}.system.fileSystems.btrfs.impermanence;
 


### PR DESCRIPTION
After migrating from snowfall-lib to purr, the lib functions are resolved under directory-based paths (e.g., `lib.cattery.module.*`, `lib.cattery.utils.*`, `lib.cattery.secrets.*`) rather than flat. This PR updates all module references to match.

**Changes:**
- Remove extra `secrets` wrapping in `lib/secrets/default.nix` (was `{ secrets = rec { ... } }`, now flatter)
- 33 files: `lib.${namespace}.mkDefaultEnabled` → `lib.${namespace}.module.mkDefaultEnabled`
- 2 files: `lib.${namespace}.getRootDomain` → `lib.${namespace}.utils.getRootDomain`
- 1 file: `lib.${namespace}.escapeSystemdPath` → `lib.${namespace}.utils.escapeSystemdPath`