### PR TITLE
refactor: migrate module args from legacy specialArgs to purr

### DIFF
--- a/checks/module-eval/default.nix
+++ b/checks/module-eval/default.nix
@@ -33,12 +33,12 @@ let
     config = { };
     options = { };
     modulesPath = pkgs.path + "/nixos/modules";
-    target = system;
-    format = "unknown";
-    virtual = false;
-    systems = [ system ];
-    host = "test";
-    user = "tester";
+    purr = {
+      name = "test";
+      host = "test";
+      user = "tester";
+      format = "unknown";
+    };
   };
 
   checkFile =

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1784276245,
-        "narHash": "sha256-o8CfkVnvQitc2VGb/UnN7ixmeTFSnt4j7cxyeKaICZM=",
+        "lastModified": 1784362630,
+        "narHash": "sha256-+XtyoaegVrsrkVAOv2ih+q1tzlF7tiBDmLT2bUlvoJg=",
         "owner": "caelestia-dots",
         "repo": "shell",
-        "rev": "00b2a0f5d6b4a3953a1c00e48c59639858abc154",
+        "rev": "be78277fe99e6ca62d64a45325e18636c962a273",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783674541,
-        "narHash": "sha256-vmUhEF/jBCZJeK0dInOls+HOAR0yiiQusN1+FZKaJss=",
+        "lastModified": 1784366307,
+        "narHash": "sha256-VKatYOZwLQ+MuNkWH6/gZYxrNeSK1Mqb7mC0H1WSu+M=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "96799f24cf1366fe88e1293c3d27521a8f2129cf",
+        "rev": "673f730d0fc8db3468c51575f1d3d777cc55e51f",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784123936,
-        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
+        "lastModified": 1784362797,
+        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
+        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1784358174,
-        "narHash": "sha256-WaeVprDrsfr5Q/TBvVVjLPmQSxqhoFV23FZpuCahvGQ=",
+        "lastModified": 1784373055,
+        "narHash": "sha256-H9LywolZgqSTFlEH01xcgCHapdX9ElS9A69qXkpl/fw=",
         "owner": "nixcafe",
         "repo": "purr",
-        "rev": "b62e61bd50d606135589c4b96d32bd079d0ae4da",
+        "rev": "61a9aa3f6df07fbf83899a3a16c6162810c6aeca",
         "type": "github"
       },
       "original": {

--- a/modules/home/shared/cli-apps/dev-kit/git/secrets/default.nix
+++ b/modules/home/shared/cli-apps/dev-kit/git/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkHomeAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/home/shared/cli-apps/security/gnupg/secrets/default.nix
+++ b/modules/home/shared/cli-apps/security/gnupg/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkHomeAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/home/shared/cli-apps/ssh/secrets/default.nix
+++ b/modules/home/shared/cli-apps/ssh/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkHomeAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/home/shared/secrets/default.nix
+++ b/modules/home/shared/secrets/default.nix
@@ -1,6 +1,6 @@
 {
   inputs,
-  host,
+  purr ? { },
   system,
   config,
   lib,
@@ -8,6 +8,7 @@
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib)
     mkOption
     mkEnableOption

--- a/modules/nixos/cli-apps/ssh/secrets/default.nix
+++ b/modules/nixos/cli-apps/ssh/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/nixos/containers/default.nix
+++ b/modules/nixos/containers/default.nix
@@ -2,12 +2,7 @@
   lib,
   inputs,
   namespace,
-  system,
-  target,
-  format,
-  virtual,
-  systems,
-  host,
+  purr ? { },
   config,
   ...
 }:
@@ -311,13 +306,7 @@ in
             inherit
               namespace
               inputs
-              system
-              target
-              format
-              virtual
-              systems
-              host
-              lib
+              purr
               ;
           });
       }

--- a/modules/nixos/services/acme/secrets/default.nix
+++ b/modules/nixos/services/acme/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) optionalString unique foldl';
   inherit (lib.${namespace}.utils) getRootDomain;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;

--- a/modules/nixos/services/cloudflared/secrets/default.nix
+++ b/modules/nixos/services/cloudflared/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) foldl';
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;

--- a/modules/nixos/services/forgejo/secrets/default.nix
+++ b/modules/nixos/services/forgejo/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) optional;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;

--- a/modules/nixos/services/gitea-actions-runner/secrets/default.nix
+++ b/modules/nixos/services/gitea-actions-runner/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) mapAttrsToList;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;

--- a/modules/nixos/services/gitea/secrets/default.nix
+++ b/modules/nixos/services/gitea/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) optional;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;

--- a/modules/nixos/services/nginx/secrets/default.nix
+++ b/modules/nixos/services/nginx/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/nixos/services/postgresql/secrets/default.nix
+++ b/modules/nixos/services/postgresql/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/nixos/services/vaultwarden/secrets/default.nix
+++ b/modules/nixos/services/vaultwarden/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/nixos/system/fileSystems/samba/secrets/default.nix
+++ b/modules/nixos/system/fileSystems/samba/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/shared/nix/secrets/default.nix
+++ b/modules/shared/nix/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib) mkAfter;
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;

--- a/modules/shared/secrets/default.nix
+++ b/modules/shared/secrets/default.nix
@@ -1,6 +1,6 @@
 {
   inputs,
-  host,
+  purr ? { },
   system,
   config,
   lib,
@@ -8,6 +8,7 @@
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib)
     mkOption
     mkEnableOption

--- a/modules/shared/services/sing-box/secrets/default.nix
+++ b/modules/shared/services/sing-box/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 

--- a/modules/shared/services/wg-quick/secrets/default.nix
+++ b/modules/shared/services/wg-quick/secrets/default.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   namespace,
-  host,
+  purr ? { },
   ...
 }:
 let
+  host = purr.host or purr.name or "localhost";
   inherit (lib.${namespace}.secrets) mkAppSecretsOption;
   inherit (config.${namespace}.secrets) files;
 


### PR DESCRIPTION
## Description
Replace legacy specialArgs (`host`, `target`, `format`, `virtual`, `systems`) with unified `purr`-based derivation across all modules.

## Changes
- **19 secrets modules**: `host` → `purr` param, derive `host = purr.host or purr.name`
- **containers module**: slim from 10 params to 5, drop `target/format/virtual/systems/host`, pass only `namespace/inputs/purr` to sub-containers
- **checks/module-eval**: replace legacy args with `purr = { name/host/user/format }`

## Checklist
- [x] `nix flake check` passes
- [x] pre-commit hooks pass (deadnix / nixfmt / statix)
- [x] All modules follow consistent `purr`-based pattern