### PR TITLE
chore: update purr and develop-templates to latest online refs

### DIFF
--- a/checks/module-eval/default.nix
+++ b/checks/module-eval/default.nix
@@ -38,6 +38,8 @@ let
       host = "test";
       user = "tester";
       format = "unknown";
+      isLinux = pkgsLib.hasSuffix "linux" system;
+      isDarwin = pkgsLib.hasSuffix "darwin" system;
     };
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1783203018,
-        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784362797,
-        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -149,11 +149,11 @@
         "templates-typst": "templates-typst"
       },
       "locked": {
-        "lastModified": 1784320069,
-        "narHash": "sha256-XCpV6BL5L8i37OJTBga5KhjFx7xDHFWeCXAFrWK+9M8=",
+        "lastModified": 1784966991,
+        "narHash": "sha256-NrVP2rEtQHmKz47wrVD4HKJON5rBupZlDgQ2BE7yzco=",
         "owner": "nixcafe",
         "repo": "develop-templates",
-        "rev": "b2b5200404a40927a150f0bd86423f5a22a9d838",
+        "rev": "339ae849e1c46a3d38ad54dcfa279a132283f662",
         "type": "github"
       },
       "original": {
@@ -331,11 +331,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784407317,
-        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
+        "lastModified": 1784546264,
+        "narHash": "sha256-jxVr5EHMYAOkFvS2k0abIvt6NqyshyWmiHHzV17sT2g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
+        "rev": "e3dea8e4792b09a6c0eb5836b0284ad05b1acba0",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783496806,
-        "narHash": "sha256-6B6CQUk1dPc8l/+otaGiYbuX8qeX/0VmSUQ+qSn0/uA=",
+        "lastModified": 1784564954,
+        "narHash": "sha256-r6DU726OPquiKVpGfhB2MdxSRpmmgXQRks+a7O4IRP0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6183ac79eadb079a1e72fa2c60915601be669100",
+        "rev": "ef1437ee629b0c2183f818190d54ed8f8fe2270b",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -492,11 +492,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1783821755,
-        "narHash": "sha256-eMPX9S6MKPyUnaOgeRfrG7OKUiAlc1AlcRinMbSB0WA=",
+        "lastModified": 1784426460,
+        "narHash": "sha256-DFY3+18Zijt5odIlo/G2gn1cXbU9rVim01NG1zHbpxs=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "228ab8523d81526e57a6ca342e1a919fb6d246a8",
+        "rev": "e978bdeeff2de8eb5454396f6557e655845b32c7",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -621,16 +621,17 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1784315558,
-        "narHash": "sha256-0QpTqh3aRApdN27hdWgS9k0+5/jD2Ets8HRBALq0fzM=",
-        "rev": "98dde42e51c547ba02cff230aadfd028e73fc831",
-        "revCount": 39,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nixcafe/purr/0.1.39%2Brev-98dde42e51c547ba02cff230aadfd028e73fc831/019f717f-7822-72a1-bd8e-765177abd006/source.tar.gz"
+        "lastModified": 1784966516,
+        "narHash": "sha256-h2o6+XuIhb5UboXkd6lzpQ+Wv5k7hCa7mLQ0tCp1quA=",
+        "owner": "nixcafe",
+        "repo": "purr",
+        "rev": "923295a2a45b0af4bfdaa5aadeda42fc4830fe1d",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nixcafe/purr/0.1.%2A.tar.gz"
+        "owner": "nixcafe",
+        "repo": "purr",
+        "type": "github"
       }
     },
     "purr_2": {
@@ -638,11 +639,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1784456339,
-        "narHash": "sha256-QcNUwymJQjWoQhL0L5U7dyfX9fJei87tKLmQLsVBvnM=",
+        "lastModified": 1784966516,
+        "narHash": "sha256-h2o6+XuIhb5UboXkd6lzpQ+Wv5k7hCa7mLQ0tCp1quA=",
         "owner": "nixcafe",
         "repo": "purr",
-        "rev": "b2a521e0fa12184aaf83567422ccd46a2c4f5102",
+        "rev": "923295a2a45b0af4bfdaa5aadeda42fc4830fe1d",
         "type": "github"
       },
       "original": {
@@ -700,11 +701,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784438913,
-        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
+        "lastModified": 1784526465,
+        "narHash": "sha256-L37teKC6oINWG4PGZLIqbphMWvSQ0PEz+aWxAk+rIDw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
+        "rev": "58c6334db52d51fc5dd8877c90b01f00cf8a696b",
         "type": "github"
       },
       "original": {

--- a/modules/shared/apps/winbox/default.nix
+++ b/modules/shared/apps/winbox/default.nix
@@ -3,11 +3,12 @@
   lib,
   namespace,
   pkgs,
+  purr,
   ...
 }:
 let
+  inherit (purr) isLinux;
   inherit (lib) optionalAttrs;
-  inherit (pkgs.stdenv.hostPlatform) isLinux;
 
   cfg = config.${namespace}.apps.winbox;
 in

--- a/modules/shared/nix/default.nix
+++ b/modules/shared/nix/default.nix
@@ -1,14 +1,13 @@
 {
-  pkgs,
   config,
   lib,
   namespace,
   inputs,
+  purr,
   ...
 }:
 let
-  inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
-  inherit (lib) optionalAttrs;
+  inherit (purr) isLinux isDarwin;
 
   cfg = config.${namespace}.nix;
 in
@@ -32,12 +31,12 @@ in
         automatic = true;
         options = "--delete-older-than 30d";
       }
-      // (optionalAttrs isLinux {
+      // (lib.optionalAttrs isLinux {
         persistent = true;
         dates = "monthly";
         randomizedDelaySec = "45min";
       })
-      // (optionalAttrs isDarwin {
+      // (lib.optionalAttrs isDarwin {
         interval = {
           Weekday = 1;
           Hour = 4;

--- a/modules/shared/services/sing-box/default.nix
+++ b/modules/shared/services/sing-box/default.nix
@@ -3,10 +3,11 @@
   config,
   lib,
   namespace,
+  purr,
   ...
 }:
 let
-  inherit (pkgs.stdenv.hostPlatform) isLinux;
+  inherit (purr) isLinux;
 
   cfg = config.${namespace}.services.sing-box;
   settingsFormat = pkgs.formats.json { };

--- a/modules/shared/services/wg-quick/default.nix
+++ b/modules/shared/services/wg-quick/default.nix
@@ -3,10 +3,11 @@
   config,
   lib,
   namespace,
+  purr,
   ...
 }:
 let
-  inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
+  inherit (purr) isLinux isDarwin;
   inherit (lib)
     mkOption
     types

--- a/modules/shared/system/fonts/default.nix
+++ b/modules/shared/system/fonts/default.nix
@@ -3,10 +3,11 @@
   config,
   lib,
   namespace,
+  purr,
   ...
 }:
 let
-  inherit (pkgs.stdenv.hostPlatform) isLinux;
+  inherit (purr) isLinux;
 
   cfg = config.${namespace}.system.fonts;
 in

--- a/modules/shared/user/default.nix
+++ b/modules/shared/user/default.nix
@@ -3,10 +3,11 @@
   lib,
   namespace,
   config,
+  purr,
   ...
 }:
 let
-  inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
+  inherit (purr) isLinux isDarwin;
   inherit (lib)
     mkDefault
     mkOption


### PR DESCRIPTION
Update purr and develop-templates from local path references to latest GitHub versions.