### PR TITLE
feat: rename pre-commit-hooks to git-hooks and update inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,17 @@
-name: CI
-
+name: "Check Nix flake on pull requests"
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-
+    branches:
+      - "main"
 jobs:
   flake-check:
-    runs-on: ubuntu-latest
-
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: DeterminateSystems/nix-installer-action@main
-
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - run: nix flake check --accept-flake-config
+      - uses: "actions/checkout@v4"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+        with:
+          determinate: true
+      - uses: "DeterminateSystems/magic-nix-cache-action@main"
+      - run: "nix flake check"

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
       - uses: "DeterminateSystems/nix-installer-action@main"
+        with:
+          determinate: true
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           name: "nixcafe/cattery-modules"

--- a/checks/git-hooks/default.nix
+++ b/checks/git-hooks/default.nix
@@ -1,8 +1,7 @@
 { inputs, system, ... }:
-inputs.pre-commit-hooks.lib.${system}.run {
+inputs.git-hooks.lib.${system}.run {
   src = ../../.;
   hooks = {
-    # formatter
     nixfmt.enable = true;
     deadnix.enable = true;
     statix.enable = true;

--- a/checks/module-eval/default.nix
+++ b/checks/module-eval/default.nix
@@ -1,10 +1,10 @@
 {
   pkgs,
   inputs,
+  system,
   ...
 }:
 let
-  inherit (pkgs) system;
   pkgsLib = pkgs.lib;
   namespace = "cattery";
   src = ../../.;

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1784448133,
-        "narHash": "sha256-vuElQeGNDrHGiHMRXhLFu6iCeOgbpw1dOc0HXj///Q0=",
+        "lastModified": 1784780170,
+        "narHash": "sha256-SF4+1jOCnySn3K2cS8kNzB3aDmV3xLdqC7eTZqgVZSc=",
         "owner": "caelestia-dots",
         "repo": "shell",
-        "rev": "027808004091e1d20f3f2e65b3598357cd52acae",
+        "rev": "55b47ebcb83ad98dad6307429fe700694cd1c971",
         "type": "github"
       },
       "original": {
@@ -135,7 +135,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "purr": "purr",
+        "purr": [
+          "purr"
+        ],
         "templates-colmena-config": "templates-colmena-config",
         "templates-java": "templates-java",
         "templates-kotlin": "templates-kotlin",
@@ -149,11 +151,11 @@
         "templates-typst": "templates-typst"
       },
       "locked": {
-        "lastModified": 1784966991,
-        "narHash": "sha256-NrVP2rEtQHmKz47wrVD4HKJON5rBupZlDgQ2BE7yzco=",
+        "lastModified": 1784980922,
+        "narHash": "sha256-wiIuXXnN3wgAfJUdd5Q5WiNkP4O2cjPtv1UnaipZZ7U=",
         "owner": "nixcafe",
         "repo": "develop-templates",
-        "rev": "339ae849e1c46a3d38ad54dcfa279a132283f662",
+        "rev": "b129d4624181533203896af1a6c54a25772e3fcf",
         "type": "github"
       },
       "original": {
@@ -215,13 +217,13 @@
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -231,20 +233,20 @@
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
+        "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
         "lastModified": 1782949081,
@@ -262,7 +264,7 @@
     },
     "flake-parts_2": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1772408722,
@@ -301,6 +303,27 @@
     },
     "git-hooks_2": {
       "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
         "flake-compat": [
           "nix-gaming",
           "flake-compat"
@@ -331,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784546264,
-        "narHash": "sha256-jxVr5EHMYAOkFvS2k0abIvt6NqyshyWmiHHzV17sT2g=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3dea8e4792b09a6c0eb5836b0284ad05b1acba0",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -379,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784564954,
-        "narHash": "sha256-r6DU726OPquiKVpGfhB2MdxSRpmmgXQRks+a7O4IRP0=",
+        "lastModified": 1784568171,
+        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "ef1437ee629b0c2183f818190d54ed8f8fe2270b",
+        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
         "type": "github"
       },
       "original": {
@@ -411,19 +434,19 @@
     },
     "nix-gaming": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks_2",
+        "git-hooks": "git-hooks_3",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1784431599,
-        "narHash": "sha256-B80p0N3Uqx4+nMl/rFK/SU+1i3UNkAAMP7TaUk1ug20=",
+        "lastModified": 1784949315,
+        "narHash": "sha256-DFb7pfxvQIzfj/UiET+jNesON0nt3+5pk11URu+Nqrc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "1aef499f40964840bf28c8e5a47ac7e8009a7e7e",
+        "rev": "a3391389b07fc616f6cc301005013f64f9d4e7e3",
         "type": "github"
       },
       "original": {
@@ -454,17 +477,17 @@
     },
     "nixos-wsl": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_5",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1784058842,
-        "narHash": "sha256-3u3tvbCIAid3Mv7RrJx13jusIEQC/HeKYhO/SUSxR3A=",
+        "lastModified": 1784642409,
+        "narHash": "sha256-hcbDqFuySAJawljt5r0sKBCJKYnbtGD0T/ZIozH1Dq0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "24c8dc8e0f2170e1a377be24dfadc7d9d21dc1ad",
+        "rev": "eaeb18da90024448a60eb1ec7132eafa4003404e",
         "type": "github"
       },
       "original": {
@@ -476,11 +499,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -491,21 +514,6 @@
       }
     },
     "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1784426460,
-        "narHash": "sha256-DFY3+18Zijt5odIlo/G2gn1cXbU9rVim01NG1zHbpxs=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e978bdeeff2de8eb5454396f6557e655845b32c7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1782614948,
         "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
@@ -520,7 +528,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1784426460,
         "narHash": "sha256-DFY3+18Zijt5odIlo/G2gn1cXbU9rVim01NG1zHbpxs=",
@@ -535,7 +543,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1772328832,
         "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
@@ -575,7 +583,7 @@
     },
     "pre-commit": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
@@ -595,55 +603,16 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "purr": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1784966516,
-        "narHash": "sha256-h2o6+XuIhb5UboXkd6lzpQ+Wv5k7hCa7mLQ0tCp1quA=",
+        "lastModified": 1784981592,
+        "narHash": "sha256-dM8bbIr3/Fgia/XZ6k4FE7O1juw8LaA42B8poXQ9ixw=",
         "owner": "nixcafe",
         "repo": "purr",
-        "rev": "923295a2a45b0af4bfdaa5aadeda42fc4830fe1d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixcafe",
-        "repo": "purr",
-        "type": "github"
-      }
-    },
-    "purr_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
-      },
-      "locked": {
-        "lastModified": 1784966516,
-        "narHash": "sha256-h2o6+XuIhb5UboXkd6lzpQ+Wv5k7hCa7mLQ0tCp1quA=",
-        "owner": "nixcafe",
-        "repo": "purr",
-        "rev": "923295a2a45b0af4bfdaa5aadeda42fc4830fe1d",
+        "rev": "c59b9427feac82d094af493d10ee6e5daa0f1628",
         "type": "github"
       },
       "original": {
@@ -680,6 +649,7 @@
         "catppuccin": "catppuccin",
         "darwin": "darwin",
         "develop-templates": "develop-templates",
+        "git-hooks": "git-hooks_2",
         "home-manager": "home-manager",
         "impermanence": "impermanence",
         "lanzaboote": "lanzaboote",
@@ -688,8 +658,7 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
         "plasma-manager": "plasma-manager",
-        "pre-commit-hooks": "pre-commit-hooks",
-        "purr": "purr_2",
+        "purr": "purr",
         "rust-overlay": "rust-overlay",
         "vscode-server": "vscode-server"
       }
@@ -701,11 +670,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784526465,
-        "narHash": "sha256-L37teKC6oINWG4PGZLIqbphMWvSQ0PEz+aWxAk+rIDw=",
+        "lastModified": 1784956772,
+        "narHash": "sha256-5polVWDhgATIQj+RUV2ZlOd5nE6cGJo+C4tOEs5vp6U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "58c6334db52d51fc5dd8877c90b01f00cf8a696b",
+        "rev": "a163bd01a6e11ac58d4f8d11669da550b5afbbc6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    pre-commit-hooks = {
+    git-hooks = {
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
@@ -80,6 +80,7 @@
     develop-templates = {
       url = "github:nixcafe/develop-templates";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.purr.follows = "purr";
     };
   };
 

--- a/modules/home/shared/desktop/addons/catppuccin/default.nix
+++ b/modules/home/shared/desktop/addons/catppuccin/default.nix
@@ -22,11 +22,9 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = {
     catppuccin = {
-      inherit (cfg) autoEnable;
-
-      enable = true;
+      inherit (cfg) autoEnable enable;
     }
     // cfg.extraOptions;
   };

--- a/modules/nixos/desktop/addons/catppuccin/default.nix
+++ b/modules/nixos/desktop/addons/catppuccin/default.nix
@@ -22,11 +22,9 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = {
     catppuccin = {
-      inherit (cfg) autoEnable;
-
-      enable = true;
+      inherit (cfg) autoEnable enable;
     }
     // cfg.extraOptions;
   };

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -12,6 +12,6 @@ pkgs.mkShell {
     statix
   ];
 
-  inherit (inputs.self.checks.${system}.pre-commit-check) shellHook;
-  buildInputs = inputs.self.checks.${system}.pre-commit-check.enabledPackages;
+  inherit (inputs.self.checks.${system}.git-hooks) shellHook;
+  buildInputs = inputs.self.checks.${system}.git-hooks.enabledPackages;
 }


### PR DESCRIPTION
## Changes

- Rename flake input `pre-commit-hooks` to `git-hooks` (upstream rename)
- Rename `checks/pre-commit-check` to `checks/git-hooks`
- Update flake inputs:
  - purr, develop-templates, home-manager, lanzaboote, NixOS-WSL, nixpkgs, nix-gaming, rust-overlay, caelestia-shell, git-hooks
- Fix catppuccin module: use `inherit (cfg) enable` instead of `mkIf` wrapper
- Pass `system` as parameter in module-eval check instead of `inherit (pkgs) system`
- Update CI workflows (simplify triggers, add determinate flag)
- Update devShell to reference git-hooks check