### PR TITLE
fix: add missing mkOption descriptions and wire dead options

### DIFF
--- a/modules/darwin/brew/default.nix
+++ b/modules/darwin/brew/default.nix
@@ -15,10 +15,12 @@ in
     brews = mkOption {
       type = listOf str;
       default = [ ];
+      description = "List of Homebrew formula packages to install.";
     };
     casks = mkOption {
       type = listOf str;
       default = [ ];
+      description = "List of Homebrew cask packages to install.";
     };
   };
 

--- a/modules/darwin/home/default.nix
+++ b/modules/darwin/home/default.nix
@@ -13,6 +13,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra home-manager configuration options forwarded to the user.";
     };
   };
 

--- a/modules/darwin/services/openssh/default.nix
+++ b/modules/darwin/services/openssh/default.nix
@@ -21,6 +21,7 @@ in
     extraOptions = lib.mkOption {
       type = lib.types.attrs;
       default = { };
+      description = "Extra services.openssh nix-darwin options merged at top level.";
     };
   };
 

--- a/modules/home/nixos/apps/browser/default.nix
+++ b/modules/home/nixos/apps/browser/default.nix
@@ -26,6 +26,7 @@ in
         "chrome"
       ]);
       default = [ "firefox" ];
+      description = "Web browsers to enable and configure.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/nixos/apps/foot/default.nix
+++ b/modules/home/nixos/apps/foot/default.nix
@@ -16,6 +16,7 @@ in
     settings = mkOption {
       type = attrs;
       default = settings.foot.settings or { };
+      description = "Foot terminal emulator configuration settings.";
     };
   };
 

--- a/modules/home/nixos/apps/remote/default.nix
+++ b/modules/home/nixos/apps/remote/default.nix
@@ -28,6 +28,7 @@ in
     needs = mkOption {
       type = listOf (enum apps);
       default = apps;
+      description = "Remote desktop clients to enable (rustdesk, krdc, remmina).";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/nixos/apps/thunderbird/default.nix
+++ b/modules/home/nixos/apps/thunderbird/default.nix
@@ -16,19 +16,22 @@ in
   options.${namespace}.apps.thunderbird = with types; {
     enable = lib.mkEnableOption "thunderbird";
     search = {
-      enable = lib.mkEnableOption "thunderbird";
+      enable = lib.mkEnableOption "search engine customization for thunderbird";
       default = mkOption {
         type = str;
         default = "nix-packages";
+        description = "Default search engine for Thunderbird.";
       };
       privateDefault = mkOption {
         type = str;
         default = "google";
+        description = "Default search engine for private mode in Thunderbird.";
       };
     };
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "Thunderbird profile settings.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/nixos/desktop/hyprland/default.nix
+++ b/modules/home/nixos/desktop/hyprland/default.nix
@@ -20,6 +20,7 @@ let
         name = mkOption {
           type = types.str;
           default = name;
+          description = "Name of the Hyprland event this callback responds to.";
         };
         execs = mkOption {
           type = types.listOf types.str;
@@ -38,10 +39,12 @@ let
         callbacks = mkOption {
           type = types.listOf types.str;
           default = [ ];
+          description = "Lua callback expressions to execute on this event.";
         };
         execFunc = mkOption {
           readOnly = true;
           type = types.str;
+          description = "Generated Lua function wrapping hl.exec_cmd calls for this event.";
           default = ''
             function(...)
               local arg = {...}
@@ -61,10 +64,12 @@ in
     require = mkOption {
       default = [ ];
       type = types.listOf types.str;
+      description = "List of Hyprland config module paths to require.";
     };
     on = mkOption {
       default = { };
       type = types.attrsOf callbackModule;
+      description = "Hyprland event callbacks keyed by event name.";
     };
   };
 

--- a/modules/home/nixos/desktop/hyprland/theme/charm-cat/wallpaper/default.nix
+++ b/modules/home/nixos/desktop/hyprland/theme/charm-cat/wallpaper/default.nix
@@ -17,6 +17,7 @@ in
     settings = mkOption {
       type = types.attrs;
       default = { };
+      description = "Wallpaper daemon (awww) configuration settings.";
     };
   };
 

--- a/modules/home/nixos/desktop/xdg/default.nix
+++ b/modules/home/nixos/desktop/xdg/default.nix
@@ -20,6 +20,7 @@ in
         default = [
           "mpv.desktop"
         ];
+        description = "Default applications for audio MIME types.";
       };
       browser = mkOption {
         type = listOf str;
@@ -27,6 +28,7 @@ in
           "chromium.desktop"
           "google-chrome.desktop"
         ];
+        description = "Default applications for browser/web MIME types.";
       };
       editor = mkOption {
         type = listOf str;
@@ -36,6 +38,7 @@ in
           "code-insiders.desktop"
           "code.desktop"
         ];
+        description = "Default applications for text/code MIME types.";
       };
       image = mkOption {
         type = listOf str;
@@ -43,24 +46,28 @@ in
           "org.nomacs.ImageLounge.desktop"
           "imv-dir.desktop"
         ];
+        description = "Default applications for image MIME types.";
       };
       video = mkOption {
         type = listOf str;
         default = [
           "mpv.desktop"
         ];
+        description = "Default applications for video MIME types.";
       };
       mailto = mkOption {
         type = listOf str;
         default = [
           "thunderbird.desktop"
         ];
+        description = "Default applications for email/mailto MIME types.";
       };
       calendar = mkOption {
         type = listOf str;
         default = [
           "thunderbird.desktop"
         ];
+        description = "Default applications for calendar MIME types.";
       };
     };
   };

--- a/modules/home/nixos/services/awww/default.nix
+++ b/modules/home/nixos/services/awww/default.nix
@@ -147,6 +147,7 @@ in
     extraOptions = mkOption {
       type = types.attrs;
       default = { };
+      description = "Extra services.awww home-manager options merged at top level.";
     };
   };
 

--- a/modules/home/nixos/system/impermanence/default.nix
+++ b/modules/home/nixos/system/impermanence/default.nix
@@ -114,10 +114,12 @@ in
         directories = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG cache directories to persist.";
         };
         files = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG cache files to persist.";
         };
       };
       config = {
@@ -128,10 +130,12 @@ in
         directories = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG config directories to persist.";
         };
         files = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG config files to persist.";
         };
       };
       data = {
@@ -142,10 +146,12 @@ in
         directories = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG data directories to persist.";
         };
         files = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG data files to persist.";
         };
       };
       state = {
@@ -156,20 +162,24 @@ in
         directories = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG state directories to persist.";
         };
         files = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Additional XDG state files to persist.";
         };
       };
     };
     directories = mkOption {
       type = listOf raw;
       default = [ ];
+      description = "Additional directories to persist across reboots.";
     };
     files = mkOption {
       type = listOf raw;
       default = [ ];
+      description = "Additional files to persist across reboots.";
     };
     persistencePath = mkOption {
       type = str;
@@ -179,6 +189,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra attributes to merge into the home persistence configuration.";
     };
   };
 

--- a/modules/home/shared/apps/ghostty/default.nix
+++ b/modules/home/shared/apps/ghostty/default.nix
@@ -16,6 +16,9 @@ in
     settings = mkOption {
       type = attrs;
       default = settings.ghostty.settings or { };
+      description = ''
+        Ghostty terminal settings.
+      '';
     };
   };
 

--- a/modules/home/shared/apps/vscode/default.nix
+++ b/modules/home/shared/apps/vscode/default.nix
@@ -17,15 +17,24 @@ in
     profiles = mkOption {
       type = attrs;
       default = settings.vscode.profiles or { };
+      description = ''
+        VSCode profiles configuration.
+      '';
     };
     commandLineArgs = mkOption {
       default = [ ];
       type = listOf str;
+      description = ''
+        Additional command-line arguments passed to VSCode.
+      '';
     };
     defaultEditor = lib.mkEnableOption "vscode to $EDITOR";
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options to pass to the vscode home-manager module.
+      '';
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/apps/wezterm/default.nix
+++ b/modules/home/shared/apps/wezterm/default.nix
@@ -16,6 +16,9 @@ in
     extraConfig = mkOption {
       type = lines;
       default = settings.wezterm.extraConfig or "return {}";
+      description = ''
+        Extra Lua configuration for WezTerm.
+      '';
     };
   };
 

--- a/modules/home/shared/apps/zed-editor/default.nix
+++ b/modules/home/shared/apps/zed-editor/default.nix
@@ -27,10 +27,16 @@ in
     userSettings = mkOption {
       type = jsonType;
       default = settings.zed-editor.userSettings or { };
+      description = ''
+        Zed editor user settings in JSON format.
+      '';
     };
     userKeymaps = mkOption {
       type = jsonType;
       default = settings.zed-editor.userKeymaps or [ ];
+      description = ''
+        Zed editor user keybindings in JSON format.
+      '';
     };
     userTasks = mkOption {
       inherit (jsonFormat) type;
@@ -54,7 +60,7 @@ in
     extensions = mkOption {
       type = with types; listOf str;
       default = settings.zed-editor.extensions or [ ];
-      description = "https://github.com/zed-industries/extensions/tree/main/extensions";
+      description = "List of Zed editor extension IDs to install. See https://github.com/zed-industries/extensions/tree/main/extensions for available extensions.";
     };
     mutableUserTasks = mkOption {
       type = types.bool;
@@ -77,6 +83,9 @@ in
     extraOptions = mkOption {
       type = with types; attrs;
       default = { };
+      description = ''
+        Extra options to pass to the zed-editor home-manager module.
+      '';
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/cli-apps/dev-kit/git/default.nix
+++ b/modules/home/shared/cli-apps/dev-kit/git/default.nix
@@ -66,6 +66,7 @@ in
     signing = mkOption {
       type = nullOr signModule;
       default = if ((user.gpg.signKey or null) != null) then { } else null;
+      description = "Git commit and tag signing configuration.";
     };
     sendEmail = mkOption {
       type = nullOr (submodule {
@@ -73,18 +74,22 @@ in
           smtpserver = mkOption {
             type = nullOr str;
             default = user.email.smtp.host or null;
+            description = "SMTP server hostname for sending patches via git send-email.";
           };
           smtpserverport = mkOption {
             type = nullOr port;
             default = user.email.smtp.port or 587;
+            description = "SMTP server port for sending patches.";
           };
           smtpencryption = mkOption {
             type = nullOr str;
             default = "tls";
+            description = "SMTP encryption method (e.g. tls, ssl).";
           };
           smtpuser = mkOption {
             type = nullOr str;
             default = user.email.userName or null;
+            description = "SMTP username for authentication.";
           };
           confirm = mkOption {
             type = enum [
@@ -95,6 +100,7 @@ in
               "auto" # is equivalent to cc + compose
             ];
             default = "auto";
+            description = "Confirmation behavior for git send-email.";
           };
         };
       });
@@ -151,10 +157,12 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "Additional git configuration settings merged into programs.git.settings.";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra home-manager programs.git options merged at top level.";
     };
   };
 

--- a/modules/home/shared/cli-apps/dev-kit/java/default.nix
+++ b/modules/home/shared/cli-apps/dev-kit/java/default.nix
@@ -28,14 +28,17 @@ in
       home = mkOption {
         type = str;
         default = ".gradle";
+        description = "Gradle user home directory relative to the user's home.";
       };
       initScripts = mkOption {
         type = attrs;
         default = { };
+        description = "Gradle init scripts to include in the build environment.";
       };
       settings = mkOption {
         type = attrs;
         default = { };
+        description = "Additional Gradle configuration settings.";
       };
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {

--- a/modules/home/shared/cli-apps/dev-kit/javascript/default.nix
+++ b/modules/home/shared/cli-apps/dev-kit/javascript/default.nix
@@ -45,6 +45,7 @@ in
         "pnpm"
         "bun"
       ];
+      description = "JavaScript package managers to enable and configure.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/cli-apps/dev-kit/jujutsu/default.nix
+++ b/modules/home/shared/cli-apps/dev-kit/jujutsu/default.nix
@@ -37,7 +37,7 @@ let
         default = "gpg";
         description = ''
           The signing method to use when signing commits and tags.
-          Valid values are `openpgp` (OpenPGP/GnuPG), `ssh` (SSH), and `x509` (X.509 certificates).
+          Valid values are `gpg` (OpenPGP/GnuPG), `gpgsm` (GPG S/MIME), and `ssh` (SSH keys).
         '';
       };
       behavior = mkOption {
@@ -73,6 +73,7 @@ let
             "${pkgs.gnupg}/bin/gpgsm"
           else
             "${pkgs.openssh}/bin/ssh-keygen";
+        description = "Path to the signing backend binary.";
       };
     };
   };
@@ -85,6 +86,7 @@ in
     signing = mkOption {
       type = nullOr signModule;
       default = if ((user.gpg.signKey or null) != null) then { } else null;
+      description = "Jujutsu commit signing configuration.";
     };
     ignores = mkOption {
       type = listOf str;
@@ -98,10 +100,12 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "Additional jujutsu configuration settings merged into programs.jujutsu.settings.";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra home-manager programs.jujutsu options merged at top level.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/cli-apps/editor/helix/default.nix
+++ b/modules/home/shared/cli-apps/editor/helix/default.nix
@@ -15,6 +15,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options to pass to the helix home-manager module.
+      '';
     };
   };
 

--- a/modules/home/shared/cli-apps/editor/neovim/default.nix
+++ b/modules/home/shared/cli-apps/editor/neovim/default.nix
@@ -15,6 +15,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options to pass to the neovim home-manager module.
+      '';
     };
   };
 

--- a/modules/home/shared/cli-apps/editor/vim/default.nix
+++ b/modules/home/shared/cli-apps/editor/vim/default.nix
@@ -15,6 +15,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options to pass to the vim home-manager module.
+      '';
     };
   };
 

--- a/modules/home/shared/cli-apps/shell/nushell/default.nix
+++ b/modules/home/shared/cli-apps/shell/nushell/default.nix
@@ -19,10 +19,12 @@ in
     settings = mkOption {
       type = attrs;
       default = settings.nushell.settings or { };
+      description = "Nushell configuration settings.";
     };
     extraConfig = mkOption {
       type = lines;
       default = "";
+      description = "Extra Nushell configuration lines appended to config.nu.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/cli-apps/shell/starship/default.nix
+++ b/modules/home/shared/cli-apps/shell/starship/default.nix
@@ -16,6 +16,7 @@ in
     settings = mkOption {
       type = attrs;
       default = settings.starship.settings or { };
+      description = "Starship prompt configuration settings.";
     };
   };
 

--- a/modules/home/shared/cli-apps/ssh/default.nix
+++ b/modules/home/shared/cli-apps/ssh/default.nix
@@ -18,6 +18,9 @@ in
     includeNames = mkOption {
       default = [ ];
       type = listOf str;
+      description = ''
+        List of secret file names to include via the Include directive.
+      '';
     };
     includes = mkOption {
       default = [ ];
@@ -36,7 +39,11 @@ in
   config = lib.mkIf cfg.enable {
     programs.ssh =
       let
-        includeFiles = map (name: cfgSecrets.files.${name}.target) (builtins.attrNames cfgSecrets.files);
+        includeFiles = map (name: cfgSecrets.files.${name}.target) (
+          builtins.filter (n: cfg.includeNames == [ ] || builtins.elem n cfg.includeNames) (
+            builtins.attrNames cfgSecrets.files
+          )
+        );
         includes = includeFiles ++ cfg.includes;
       in
       {

--- a/modules/home/shared/cli-apps/tool/fastfetch/default.nix
+++ b/modules/home/shared/cli-apps/tool/fastfetch/default.nix
@@ -15,6 +15,7 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "Fastfetch configuration settings.";
     };
   };
 

--- a/modules/home/shared/cli-apps/tool/gh/default.nix
+++ b/modules/home/shared/cli-apps/tool/gh/default.nix
@@ -15,10 +15,12 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "GitHub CLI configuration settings.";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra home-manager programs.gh options merged at top level.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/cli-apps/tool/hyfetch/default.nix
+++ b/modules/home/shared/cli-apps/tool/hyfetch/default.nix
@@ -15,6 +15,7 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "Hyfetch configuration settings.";
     };
   };
 

--- a/modules/home/shared/cli-apps/tool/tldr/default.nix
+++ b/modules/home/shared/cli-apps/tool/tldr/default.nix
@@ -19,6 +19,7 @@ in
     period = mkOption {
       type = str;
       default = "weekly";
+      description = "How often to update the tldr cache (e.g. hourly, daily, weekly).";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/home/shared/desktop/addons/catppuccin/default.nix
+++ b/modules/home/shared/desktop/addons/catppuccin/default.nix
@@ -19,6 +19,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = user.settings.catppuccin.home or { };
+      description = ''
+        Extra options to pass to the catppuccin home-manager module.
+      '';
     };
   };
 

--- a/modules/home/shared/secrets/default.nix
+++ b/modules/home/shared/secrets/default.nix
@@ -41,23 +41,38 @@ let
           name = mkOption {
             type = str;
             default = name;
+            description = ''
+              Name of the secret used as a local identifier.
+            '';
           };
           secretName = mkOption {
             type = str;
             default = "${secretPrefixName}/${config.name}";
+            description = ''
+              Full qualified name used as the key in {option}`age.secrets`.
+            '';
           };
           file = mkOption {
             type = path;
             default = "${hosts-secrets}/${filePrefixPath}/${config.name}.age";
+            description = ''
+              Path to the age-encrypted secret file.
+            '';
           };
           mode = mkOption {
             type = str;
-            default = "0400"; # Read-only
+            default = "0400";
+            description = ''
+              File permission mode of the decrypted secret.
+            '';
           };
           path = mkOption {
             type = str;
             default = secrets.${config.secretName}.path;
             readOnly = true;
+            description = ''
+              Path where the decrypted secret will be placed.
+            '';
           };
           symlink = mkEnableOption "symlinking secrets to their destination" // {
             default = true;
@@ -85,6 +100,9 @@ let
                   secretPrefixName = "${prefixName}users/${name}";
                 });
                 default = { };
+                description = ''
+                  Attribute set of user-specific secrets.
+                '';
               };
             }
           )
@@ -97,6 +115,9 @@ let
           secretPrefixName = "${prefixName}global";
         });
         default = { };
+        description = ''
+          Attribute set of global secrets shared across all users.
+        '';
       };
     };
 
@@ -146,6 +167,9 @@ in
     secretsPath = mkOption {
       type = path;
       default = "${homeDir}/agenix";
+      description = ''
+        Directory path containing the age-encrypted secret files.
+      '';
     };
     # hosts private config
     hosts = secretSet {
@@ -159,6 +183,9 @@ in
       type = attrs;
       default = (toAgeSecrets cfg.shared) // (toAgeSecrets cfg.hosts);
       readOnly = true;
+      description = ''
+        Merged attribute set of all agenix secrets from hosts and shared configurations.
+      '';
     };
   };
 

--- a/modules/home/shared/services/gpg-agent/default.nix
+++ b/modules/home/shared/services/gpg-agent/default.nix
@@ -80,6 +80,9 @@ in
     extraOptions = mkOption {
       type = types.attrs;
       default = { };
+      description = ''
+        Extra options to pass to the gpg-agent home-manager module.
+      '';
     };
   };
 

--- a/modules/home/user/default.nix
+++ b/modules/home/user/default.nix
@@ -25,15 +25,24 @@ in
     name = mkOption {
       type = str;
       default = cfg.settings.name or "nixos";
+      description = ''
+        The name of the user account.
+      '';
     };
     realName = mkOption {
       type = nullOr str;
       default = cfg.settings.realName or cfg.name or null;
+      description = ''
+        The real (full) name of the user.
+      '';
     };
     email = {
       address = mkOption {
         type = nullOr str;
         default = cfg.settings.email.address or null;
+        description = ''
+          The email address of the user.
+        '';
       };
       userName = mkOption {
         type = nullOr str;
@@ -56,6 +65,9 @@ in
             port = mkOption {
               type = nullOr port;
               default = 993;
+              description = ''
+                The port of the IMAP server.
+              '';
             };
           };
         });
@@ -74,6 +86,9 @@ in
             port = mkOption {
               type = nullOr port;
               default = 587;
+              description = ''
+                The port of the SMTP server.
+              '';
             };
           };
         });
@@ -84,15 +99,24 @@ in
       type = nullOr str;
       default = config.home.homeDirectory;
       readOnly = true;
+      description = ''
+        The path to the user's home directory.
+      '';
     };
     gpg = {
       signKey = mkOption {
         type = nullOr str;
         default = cfg.settings.gpg.signKey or null;
+        description = ''
+          The GPG key used for signing.
+        '';
       };
       encryptKey = mkOption {
         type = nullOr str;
         default = cfg.settings.gpg.encryptKey or null;
+        description = ''
+          The GPG key used for encryption.
+        '';
       };
     };
     defaultUserShell = lib.mkOption {
@@ -102,10 +126,16 @@ in
           pkgs.${cfg.settings.defaultUserShell}
         else
           null;
+      description = ''
+        The default login shell for the user.
+      '';
     };
     settings = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra settings passed through from the flake configuration.
+      '';
     };
   };
 

--- a/modules/nixos/cli-apps/ssh/default.nix
+++ b/modules/nixos/cli-apps/ssh/default.nix
@@ -23,6 +23,9 @@ in
     knownHostsFileNames = mkOption {
       default = [ ];
       type = listOf str;
+      description = ''
+        List of filenames in /etc/ssh/ to include as global known hosts.
+      '';
     };
     knownHostsFiles = mkOption {
       default = [ ];

--- a/modules/nixos/containers/default.nix
+++ b/modules/nixos/containers/default.nix
@@ -68,10 +68,12 @@ let
         modules = mkOption {
           type = listOf raw;
           default = [ ];
+          description = "Extra NixOS modules to import into the container's configuration.";
         };
         userName = mkOption {
           type = str;
           default = "root";
+          description = "The primary user to configure inside the container.";
         };
         networkMode = mkOption {
           type = enum [
@@ -114,21 +116,25 @@ let
           type = nullOr str;
           default = if config.autoGenerateStaticIp then generateIps.${name}.hostAddress else null;
           example = "10.231.136.1";
+          description = "IPv4 address of the host-side of the veth pair.";
         };
         hostAddress6 = mkOption {
           type = nullOr str;
           default = if config.autoGenerateStaticIp then generateIps.${name}.hostAddress6 else null;
           example = "fc00::1";
+          description = "IPv6 address of the host-side of the veth pair.";
         };
         localAddress = mkOption {
           type = nullOr str;
           default = if config.autoGenerateStaticIp then generateIps.${name}.localAddress else null;
           example = "10.231.136.2";
+          description = "IPv4 address of the container-side of the veth pair.";
         };
         localAddress6 = mkOption {
           type = nullOr str;
           default = if config.autoGenerateStaticIp then generateIps.${name}.localAddress6 else null;
           example = "fc00::2";
+          description = "IPv6 address of the container-side of the veth pair.";
         };
         autoGenerateStaticIp = lib.mkEnableOption "generate container static ip" // {
           default = config.networkMode == "none";
@@ -142,7 +148,7 @@ let
             }
           '';
           description = ''
-            An extra list of directories that is bound to the container.
+            An extra attribute set of directories that is bound to the container.
           '';
         };
         hostModules = {
@@ -165,10 +171,12 @@ let
             services = mkOption {
               type = listOf (enum servicesEnum);
               default = intersectLists [ "${name}" ] servicesEnum;
+              description = "Host services to automatically enable and start in the container.";
             };
             shared.services = mkOption {
               type = listOf (enum sharedServicesEnum);
               default = intersectLists [ "${name}" ] sharedServicesEnum;
+              description = "Shared services to automatically enable and start in the container.";
             };
             bindSecretsEtc = lib.mkEnableOption ''
               Binding host decryption secrets etc.
@@ -188,10 +196,12 @@ let
         config = mkOption {
           type = attrs;
           default = { };
+          description = "NixOS configuration attributes to merge into the container's configuration.";
         };
         extraOptions = mkOption {
           type = attrs;
           default = { };
+          description = "Extra attributes to merge at the top level of the container's NixOS configuration.";
         };
       };
     }

--- a/modules/nixos/desktop/addons/catppuccin/default.nix
+++ b/modules/nixos/desktop/addons/catppuccin/default.nix
@@ -19,6 +19,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = user.settings.catppuccin.global or { };
+      description = ''
+        Extra options to pass to the catppuccin NixOS module.
+      '';
     };
   };
 

--- a/modules/nixos/home/default.nix
+++ b/modules/nixos/home/default.nix
@@ -13,6 +13,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra home-manager configuration options forwarded to the user.";
     };
   };
 

--- a/modules/nixos/security/pam/default.nix
+++ b/modules/nixos/security/pam/default.nix
@@ -11,6 +11,9 @@ in
   options.${namespace}.security.pam = lib.mkOption {
     type = lib.types.attrs;
     default = { };
+    description = ''
+      PAM configuration options.
+    '';
   };
 
   config = lib.mkIf (cfg != { }) {

--- a/modules/nixos/services/acme/default.nix
+++ b/modules/nixos/services/acme/default.nix
@@ -30,10 +30,16 @@ in
     email = mkOption {
       type = nullOr str;
       default = user.email.address or null;
+      description = ''
+        Email address for ACME account registration and certificate expiration notices.
+      '';
     };
     group = mkOption {
       type = str;
       default = if nginx.enable then "nginx" else "acme";
+      description = ''
+        Group owner of the ACME certificate directories.
+      '';
     };
     dnsProvider = mkOption {
       type = nullOr str;
@@ -45,18 +51,30 @@ in
     postRun = mkOption {
       type = lines;
       default = "";
+      description = ''
+        Shell commands executed after a certificate is issued or renewed.
+      '';
     };
     reloadServices = mkOption {
       type = listOf str;
       default = optional nginx.enable "nginx.service";
+      description = ''
+        Systemd services to reload after a certificate is issued or renewed.
+      '';
     };
     certs = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        ACME certificate configurations keyed by domain name.
+      '';
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the ACME service configuration.
+      '';
     };
   };
 
@@ -68,6 +86,8 @@ in
           email
           group
           dnsProvider
+          postRun
+          reloadServices
           ;
       };
       certs = concatMapAttrs (name: value: {

--- a/modules/nixos/services/cloud-init/default.nix
+++ b/modules/nixos/services/cloud-init/default.nix
@@ -16,6 +16,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.cloud-init NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/cloudflared/default.nix
+++ b/modules/nixos/services/cloudflared/default.nix
@@ -15,10 +15,18 @@ in
     tunnels = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Cloudflare tunnel configurations keyed by tunnel name.
+        Each tunnel is automatically assigned a credentials file at
+        /etc/cloudflared/credentials/<name>.json.
+      '';
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the cloudflared service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/cron/default.nix
+++ b/modules/nixos/services/cron/default.nix
@@ -15,6 +15,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.cron NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/docker/default.nix
+++ b/modules/nixos/services/docker/default.nix
@@ -15,6 +15,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra virtualisation.docker NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/forgejo/default.nix
+++ b/modules/nixos/services/forgejo/default.nix
@@ -37,10 +37,17 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Forgejo settings passed directly to the service configuration.
+        See <https://forgejo.org/docs/latest/admin/config-cheat-sheet>.
+      '';
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the Forgejo service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/getty/default.nix
+++ b/modules/nixos/services/getty/default.nix
@@ -15,10 +15,12 @@ in
     autologinUser = mkOption {
       type = types.nullOr types.str;
       default = config.${namespace}.user.name;
+      description = "Username to automatically log in on the console.";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.getty NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/gitea-actions-runner/default.nix
+++ b/modules/nixos/services/gitea-actions-runner/default.nix
@@ -44,10 +44,16 @@ in
               name = mkOption {
                 type = str;
                 default = name;
+                description = ''
+                  Name of this runner instance, used for registration and identification.
+                '';
               };
               url = mkOption {
                 type = str;
                 default = cfg.url;
+                description = ''
+                  Base URL of the Gitea/Forgejo instance this runner connects to.
+                '';
               };
               tokenFile = mkOption {
                 type = nullOr (either str path);
@@ -84,6 +90,9 @@ in
               extraOptions = mkOption {
                 type = attrs;
                 default = { };
+                description = ''
+                  Extra options merged into this runner instance's configuration.
+                '';
               };
             };
           }
@@ -96,6 +105,9 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the gitea-actions-runner service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/gitea/default.nix
+++ b/modules/nixos/services/gitea/default.nix
@@ -37,10 +37,17 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Gitea settings passed directly to the service configuration.
+        See <https://docs.gitea.com/administration/config-cheat-sheet>.
+      '';
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the Gitea service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/nginx/default.nix
+++ b/modules/nixos/services/nginx/default.nix
@@ -24,18 +24,30 @@ in
     commonHttpConfig = mkOption {
       type = types.lines;
       default = "";
+      description = ''
+        Lines to prepend to the main nginx http block configuration.
+      '';
     };
     httpConfig = mkOption {
       type = types.lines;
       default = "";
+      description = ''
+        Lines appended to the main nginx http block configuration.
+      '';
     };
     appendHttpConfig = mkOption {
       type = types.lines;
       default = "";
+      description = ''
+        Lines appended to the end of the main nginx http block configuration.
+      '';
     };
     virtualHosts = mkOption {
       type = types.attrs;
       default = { };
+      description = ''
+        Declarative specification of nginx virtual hosts.
+      '';
     };
     preStart = mkOption {
       type = types.lines;
@@ -47,6 +59,9 @@ in
     extraOptions = mkOption {
       type = types.attrs;
       default = { };
+      description = ''
+        Extra options merged into the nginx service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/openssh/default.nix
+++ b/modules/nixos/services/openssh/default.nix
@@ -15,10 +15,12 @@ in
     settings = mkOption {
       type = attrs;
       default = { };
+      description = "OpenSSH service configuration settings.";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.openssh NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/postgresql/default.nix
+++ b/modules/nixos/services/postgresql/default.nix
@@ -20,6 +20,10 @@ in
     package = mkOption {
       type = nullOr package;
       default = null;
+      description = ''
+        The PostgreSQL package to use. Defaults to the system-wide PostgreSQL package
+        when set to null.
+      '';
     };
     openFirewall = lib.mkEnableOption "postgresql open firewall";
     configFile = {
@@ -38,10 +42,16 @@ in
       identMapPath = mkOption {
         type = path;
         default = "/etc/postgresql/pg_ident.conf";
+        description = ''
+          Path to the PostgreSQL ident map configuration file.
+        '';
       };
       authenticationPath = mkOption {
         type = path;
         default = "/etc/postgresql/pg_hba.conf";
+        description = ''
+          Path to the PostgreSQL host-based authentication (pg_hba) configuration file.
+        '';
       };
     };
     settings = {
@@ -60,6 +70,9 @@ in
       port = mkOption {
         type = port;
         default = 5432;
+        description = ''
+          Port on which PostgreSQL listens for connections.
+        '';
       };
       jit = mkOption {
         type = enum [
@@ -67,11 +80,17 @@ in
           "off"
         ];
         default = "off";
+        description = ''
+          Whether to enable JIT compilation for PostgreSQL.
+        '';
       };
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra options merged into the PostgreSQL service configuration.
+      '';
     };
   };
 

--- a/modules/nixos/services/smartdns/default.nix
+++ b/modules/nixos/services/smartdns/default.nix
@@ -21,10 +21,12 @@ in
     openFirewall = mkOption {
       type = types.bool;
       default = true;
+      description = "Whether to open firewall ports for DNS (53, 853, 443).";
     };
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.smartdns NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/tailscale/default.nix
+++ b/modules/nixos/services/tailscale/default.nix
@@ -16,6 +16,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.tailscale NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/vaultwarden/default.nix
+++ b/modules/nixos/services/vaultwarden/default.nix
@@ -35,6 +35,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.vaultwarden NixOS options merged at top level.";
     };
   };
 

--- a/modules/nixos/services/vscode-server/default.nix
+++ b/modules/nixos/services/vscode-server/default.nix
@@ -15,6 +15,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra services.vscode-server NixOS options merged at top level.";
     };
     persistence = lib.mkEnableOption "add files and directories to impermanence" // {
       default = true;

--- a/modules/nixos/system/boot/efi/default.nix
+++ b/modules/nixos/system/boot/efi/default.nix
@@ -15,6 +15,7 @@ in
     configurationLimit = mkOption {
       type = int;
       default = 100;
+      description = "Maximum number of generations to keep in the systemd-boot menu.";
     };
   };
 

--- a/modules/nixos/system/boot/grub/default.nix
+++ b/modules/nixos/system/boot/grub/default.nix
@@ -17,10 +17,7 @@ in
       type = types.str;
       description = ''
         The device on which the GRUB boot loader will be installed.
-        The special value `nodev` means that a GRUB
-        boot menu will be generated, but GRUB itself will not
-        actually be installed.  To install GRUB on multiple devices,
-        use `boot.loader.grub.devices`.
+        Set to 'nodev' for EFI boot.
       '';
       default = "";
       example = "/dev/disk/by-id/wwn-0x500001234567890a";
@@ -28,6 +25,9 @@ in
     configurationLimit = mkOption {
       type = int;
       default = 100;
+      description = ''
+        Maximum number of configurations in the GRUB menu.
+      '';
     };
   };
 

--- a/modules/nixos/system/boot/kernel/default.nix
+++ b/modules/nixos/system/boot/kernel/default.nix
@@ -16,12 +16,14 @@ in
     version = mkOption {
       type = str;
       default = "latest";
+      description = "Linux kernel version to use (e.g. 'latest', '6.12', '6.6').";
     };
     sysctl = mkOption {
       type = attrs;
       default = { };
+      description = "Kernel sysctl parameters to set (e.g. 'net.ipv4.ip_forward').";
     };
-    useIpForward = lib.mkEnableOption "just like: `net.ipv4.ip_forward=1`, overwritten if sysctl ip_forward is set.";
+    useIpForward = lib.mkEnableOption "IP forwarding";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/nixos/system/boot/lanzaboote/default.nix
+++ b/modules/nixos/system/boot/lanzaboote/default.nix
@@ -19,6 +19,9 @@ in
     extraOptions = lib.mkOption {
       type = lib.types.attrs;
       default = { };
+      description = ''
+        Extra options to pass to the lanzaboote NixOS module.
+      '';
     };
   };
 

--- a/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
+++ b/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
@@ -22,23 +22,28 @@ in
           options = with types; {
             device = mkOption {
               type = str;
+              description = "Block device path for the BTRFS filesystem (e.g. /dev/sda1).";
             };
             tempDir = mkOption {
               type = str;
-              default = "/btrfs_${config.subvol}_tmp";
+              default = "/btrfs_''${config.subvol}_tmp";
+              description = "Temporary mount directory used during the BTRFS rollback process.";
             };
             oldSubvolDir = mkOption {
               type = str;
-              default = "old_${config.subvol}";
+              default = "old_''${config.subvol}";
+              description = "Directory name where old snapshot subvolumes are archived.";
             };
             subvol = mkOption {
               type = str;
               default = name;
+              description = "Name of the BTRFS subvolume to manage.";
             };
           };
         }
       )
     );
+    description = "Per-filesystem BTRFS subvolume rollback configuration for impermanence. Creates an initrd systemd service that rolls back snapshots on boot.";
     default = { };
   };
 

--- a/modules/nixos/system/fileSystems/samba/default.nix
+++ b/modules/nixos/system/fileSystems/samba/default.nix
@@ -30,10 +30,12 @@ let
         hostUrl = mkOption {
           type = str;
           default = "";
+          description = "Host URL or IP address of the Samba server.";
         };
         binds = mkOption {
           type = attrsOf (bindType name);
           default = { };
+          description = "Samba share bindings mapping share names to their mount configuration.";
         };
       };
     }
@@ -45,23 +47,28 @@ let
         uid = mkOption {
           type = int;
           default = uid;
+          description = "User ID to own the mounted files.";
         };
         gid = mkOption {
           type = int;
           default = gid;
+          description = "Group ID to own the mounted files.";
         };
         autoMountOpts = mkOption {
           type = str;
+          description = "Systemd automount options to prevent hanging on network split.";
           # this line prevents hanging on network split
           default = "x-systemd.automount,noauto,x-systemd.idle-timeout=60,x-systemd.device-timeout=5s,x-systemd.mount-timeout=5s";
         };
         secretsPath = mkOption {
           type = path;
-          default = "/etc/samba/secrets/${sambaName}.conf";
+          default = "/etc/samba/secrets/''${sambaName}.conf";
+          description = "Path to the credentials file for this Samba share.";
         };
         extraOptions = mkOption {
           type = listOf str;
           default = [ ];
+          description = "Extra CIFS mount options for this share.";
         };
       };
     };
@@ -87,6 +94,7 @@ in
     client = mkOption {
       type = attrsOf sambaType;
       default = { };
+      description = "Samba client server configurations keyed by server name.";
     };
   };
 

--- a/modules/nixos/system/impermanence/default.nix
+++ b/modules/nixos/system/impermanence/default.nix
@@ -26,10 +26,12 @@ in
     directories = mkOption {
       type = listOf raw;
       default = [ ];
+      description = "Additional directories to persist across reboots.";
     };
     files = mkOption {
       type = listOf raw;
       default = [ ];
+      description = "Additional files to persist across reboots.";
     };
     persistencePath = mkOption {
       type = str;
@@ -39,6 +41,7 @@ in
     extraOptions = mkOption {
       type = attrs;
       default = { };
+      description = "Extra attributes to merge into the persistence configuration.";
     };
   };
 

--- a/modules/nixos/system/proxmox/lxc/default.nix
+++ b/modules/nixos/system/proxmox/lxc/default.nix
@@ -21,10 +21,16 @@ in
     manageNetwork = mkOption {
       type = types.bool;
       default = true;
+      description = ''
+        Whether to let Proxmox manage the network configuration.
+      '';
     };
     manageHostName = mkOption {
       type = types.bool;
       default = true;
+      description = ''
+        Whether to let Proxmox manage the hostname.
+      '';
     };
   };
 

--- a/modules/shared/cli-apps/security/gnupg/default.nix
+++ b/modules/shared/cli-apps/security/gnupg/default.nix
@@ -20,6 +20,9 @@ in
       extraOptions = mkOption {
         type = types.attrs;
         default = { };
+        description = ''
+          Extra options to pass to the GnuPG agent configuration.
+        '';
       };
     };
   };

--- a/modules/shared/secrets/default.nix
+++ b/modules/shared/secrets/default.nix
@@ -43,23 +43,38 @@ let
           name = mkOption {
             type = str;
             default = name;
+            description = ''
+              Name of the secret used as a local identifier.
+            '';
           };
           secretName = mkOption {
             type = str;
             default = "${secretPrefixName}/${config.name}";
+            description = ''
+              Full qualified name used as the key in {option}`age.secrets`.
+            '';
           };
           file = mkOption {
             type = path;
             default = "${hosts-secrets}/${filePrefixPath}/${config.name}.age";
+            description = ''
+              Path to the age-encrypted secret file.
+            '';
           };
           mode = mkOption {
             type = str;
-            default = "0400"; # Read-only
+            default = "0400";
+            description = ''
+              File permission mode of the decrypted secret.
+            '';
           };
           path = mkOption {
             type = str;
             default = secrets.${config.secretName}.path;
             readOnly = true;
+            description = ''
+              Path where the decrypted secret will be placed.
+            '';
           };
           symlink = mkEnableOption "symlinking secrets to their destination" // {
             default = true;
@@ -67,10 +82,16 @@ let
           owner = mkOption {
             type = str;
             default = owner;
+            description = ''
+              User that owns the decrypted secret file.
+            '';
           };
           group = mkOption {
             type = str;
             default = users.${config.owner}.group or "0";
+            description = ''
+              Group that owns the decrypted secret file.
+            '';
           };
         };
       }
@@ -96,6 +117,9 @@ let
                   secretPrefixName = "${prefixName}users/${name}";
                 });
                 default = { };
+                description = ''
+                  Attribute set of user-specific secrets.
+                '';
               };
             }
           )
@@ -109,6 +133,9 @@ let
           secretPrefixName = "${prefixName}global";
         });
         default = { };
+        description = ''
+          Attribute set of global secrets shared across all users.
+        '';
       };
     };
 
@@ -160,6 +187,9 @@ in
     secretsPath = mkOption {
       type = path;
       default = "${homeDir}/agenix";
+      description = ''
+        Directory path containing the age-encrypted secret files.
+      '';
     };
     # hosts private config
     hosts = secretSet {
@@ -173,6 +203,9 @@ in
       type = attrs;
       default = (toAgeSecrets cfg.shared) // (toAgeSecrets cfg.hosts);
       readOnly = true;
+      description = ''
+        Merged attribute set of all agenix secrets from hosts and shared configurations.
+      '';
     };
   };
 

--- a/modules/shared/services/wg-quick/default.nix
+++ b/modules/shared/services/wg-quick/default.nix
@@ -29,6 +29,9 @@ in
       type = str;
       default = prefix;
       readOnly = true;
+      description = ''
+        The directory prefix where WireGuard configuration files are stored.
+      '';
     };
     configNames = mkOption {
       type = listOf str;

--- a/modules/shared/system/ulimit/default.nix
+++ b/modules/shared/system/ulimit/default.nix
@@ -15,6 +15,9 @@ in
     openFilesLimit = mkOption {
       type = types.int;
       default = 2048;
+      description = ''
+        Maximum number of open file descriptors.
+      '';
     };
   };
 

--- a/modules/shared/user/default.nix
+++ b/modules/shared/user/default.nix
@@ -27,22 +27,31 @@ in
     name = mkOption {
       type = str;
       default = cfg.settings.name or "nixos";
+      description = ''
+        The name of the user account.
+      '';
     };
     realName = mkOption {
       type = nullOr str;
       default = cfg.settings.realName or cfg.name or null;
+      description = ''
+        The real (full) name of the user. Consumed by home-manager for git/email config.
+      '';
     };
     email = {
       address = mkOption {
         type = nullOr str;
         default = cfg.settings.email.address or null;
+        description = ''
+          The email address of the user. Consumed by home-manager, not directly by this module.
+        '';
       };
       userName = mkOption {
         type = nullOr str;
         default = cfg.email.address;
         description = ''
           The server username of this account. This will be used as
-          the SMTP, IMAP, and JMAP user name.
+          the SMTP, IMAP, and JMAP user name. Consumed by home-manager.
         '';
       };
       imap = mkOption {
@@ -58,10 +67,16 @@ in
             port = mkOption {
               type = nullOr port;
               default = 993;
+              description = ''
+                The port of the IMAP server.
+              '';
             };
           };
         });
         default = cfg.settings.email.imap or null;
+        description = ''
+          IMAP account configuration. Consumed by home-manager for email account configuration.
+        '';
       };
       smtp = mkOption {
         type = nullOr (submodule {
@@ -76,50 +91,89 @@ in
             port = mkOption {
               type = nullOr port;
               default = 587;
+              description = ''
+                The port of the SMTP server.
+              '';
             };
           };
         });
         default = cfg.settings.email.smtp or null;
+        description = ''
+          SMTP account configuration. Consumed by home-manager for email account configuration.
+        '';
       };
     };
     home = mkOption {
       type = nullOr str;
       default = user.home;
       readOnly = true;
+      description = ''
+        The path to the user's home directory.
+      '';
     };
     uid = mkOption {
       type = nullOr int;
       default = user.uid;
       readOnly = true;
+      description = ''
+        The user ID (UID) of the user.
+      '';
     };
     gid = mkOption {
       type = nullOr int;
       default = if isLinux then config.users.groups.${linuxUserGroup}.gid else user.gid;
       readOnly = true;
+      description = ''
+        The group ID (GID) of the user's primary group.
+      '';
     };
-    useSecretPasswordFile = lib.mkEnableOption "use secret password file to `hashedPasswordFile`";
+    useSecretPasswordFile = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to use a secret password file instead of `hashedPasswordFile`.
+        Also sets `mutableUsers = false` when enabled (Linux only).
+        Configures agenix integration for the password file.
+      '';
+    };
     initialHashedPassword = mkOption {
       type = nullOr str;
       default = cfg.settings.initialHashedPassword or null;
+      description = ''
+        An initial hashed password for the user account (Linux only).
+        Use `mkpasswd -m scrypt` to generate.
+      '';
     };
     authorizedKeys = {
       keys = lib.mkOption {
         type = listOf singleLineStr;
         default = cfg.settings.authorizedKeys.keys or [ ];
+        description = ''
+          A list of SSH authorized keys as strings.
+        '';
       };
       keyFiles = lib.mkOption {
         type = listOf path;
         default = [ ];
+        description = ''
+          A list of paths to files containing SSH authorized keys.
+        '';
       };
     };
     gpg = {
       signKey = mkOption {
         type = nullOr str;
         default = cfg.settings.gpg.signKey or null;
+        description = ''
+          The GPG key used for signing. Consumed by home-manager for GPG signing configuration.
+        '';
       };
       encryptKey = mkOption {
         type = nullOr str;
         default = cfg.settings.gpg.encryptKey or null;
+        description = ''
+          The GPG key used for encryption. Consumed by home-manager for GPG encryption configuration.
+        '';
       };
     };
     defaultUserShell = lib.mkOption {
@@ -129,10 +183,17 @@ in
           pkgs.${cfg.settings.defaultUserShell}
         else
           null;
+      description = ''
+        The default login shell for the user. On Linux, sets the system-wide
+        `users.defaultUserShell`. On Darwin, sets the per-user shell.
+      '';
     };
     settings = mkOption {
       type = attrs;
       default = { };
+      description = ''
+        Extra settings passed through from the flake configuration.
+      '';
     };
   };
 


### PR DESCRIPTION
Add 180+ missing description fields across 68 module files. Also fix inaccurate descriptions and wire dead options (acme postRun/reloadServices, ssh includeNames). All nix flake check passes.