### PR TITLE
feat: add NAS room with storage services

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784343464,
-        "narHash": "sha256-nCbqEHtKdC+K7Nm55s1NtvW8pjMkN/ln9y53DJWnfVY=",
+        "lastModified": 1784950224,
+        "narHash": "sha256-kAblkqaFzElLUXjA1Mh/FAWW2643bF2ZVINJjLx/MA0=",
         "owner": "caelestia-dots",
         "repo": "cli",
-        "rev": "0f20487cba585950de850d76e5ced63628453a36",
+        "rev": "c788ba3ab83767b0fd44dcb323875121c313e674",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         "quickshell": "quickshell"
       },
       "locked": {
-        "lastModified": 1784780170,
-        "narHash": "sha256-SF4+1jOCnySn3K2cS8kNzB3aDmV3xLdqC7eTZqgVZSc=",
+        "lastModified": 1785140775,
+        "narHash": "sha256-H3jQog6kdTD/3O+ySlN3z0b2pOHFj/7O+joK2K9wByM=",
         "owner": "caelestia-dots",
         "repo": "shell",
-        "rev": "55b47ebcb83ad98dad6307429fe700694cd1c971",
+        "rev": "fbb3d1be076b34b7e83e4470f4ef3b76a10ec496",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1784407669,
-        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
+        "lastModified": 1784564969,
+        "narHash": "sha256-TkTWNhJV/8Wk3czlbz4bwHZkFCaCHPsOy+oJe4PUiXg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
+        "rev": "7930f6c291de6f83c257839d434592aa085f290a",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784913159,
-        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
+        "lastModified": 1785306346,
+        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
+        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784568171,
-        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
+        "lastModified": 1785142311,
+        "narHash": "sha256-2hj+F0SxJ9tVtJSGQpoO53vtrXxbeqURz65tkmm15GE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
+        "rev": "683b7f72db7202e4ad037c58fac53b3f7c12f980",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784949315,
-        "narHash": "sha256-DFb7pfxvQIzfj/UiET+jNesON0nt3+5pk11URu+Nqrc=",
+        "lastModified": 1785207248,
+        "narHash": "sha256-SrVCwM5vEDVDiHasiYgoakQWTfyog/MU63PFz2RneBU=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "a3391389b07fc616f6cc301005013f64f9d4e7e3",
+        "rev": "424ce3e87bef8b7f2e6fa3c748cfaaafcf0d4c9b",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784440659,
-        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
+        "lastModified": 1785046085,
+        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
+        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1784981592,
-        "narHash": "sha256-dM8bbIr3/Fgia/XZ6k4FE7O1juw8LaA42B8poXQ9ixw=",
+        "lastModified": 1785081491,
+        "narHash": "sha256-7+Evz6CX+y6kDqyTB2U8y1SHTK7tl/uQc7LPPaLEnlI=",
         "owner": "nixcafe",
         "repo": "purr",
-        "rev": "c59b9427feac82d094af493d10ee6e5daa0f1628",
+        "rev": "c0f720f12c39c9bfd3bd0c0490453ee8f9266cae",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783673918,
-        "narHash": "sha256-cFG5vnmjJcZRVCSUaqQLOdwkX6iqF6bY8IvvmBSGSRs=",
+        "lastModified": 1784799776,
+        "narHash": "sha256-6AM0doj8hSNav9qkX4dOHOp1LSjegdQ+VmzDz9MnWAs=",
         "ref": "refs/heads/master",
-        "rev": "4df562dfb2475a9057f0f33a8db75808efad8670",
-        "revCount": 830,
+        "rev": "10b439fc6e3fd65c15fe1c486271b31da05ed023",
+        "revCount": 833,
         "type": "git",
         "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
       },
@@ -670,11 +670,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784956772,
-        "narHash": "sha256-5polVWDhgATIQj+RUV2ZlOd5nE6cGJo+C4tOEs5vp6U=",
+        "lastModified": 1785302874,
+        "narHash": "sha256-fpKEww3TJoo1ANHO2q918ei+ayOrp0YEQAO1DuBLOB4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a163bd01a6e11ac58d4f8d11669da550b5afbbc6",
+        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
         "type": "github"
       },
       "original": {

--- a/modules/home/room/server/nas/default.nix
+++ b/modules/home/room/server/nas/default.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
+
+  cfg = config.${namespace}.room.server.nas;
+in
+{
+  options.${namespace}.room.server.nas = {
+    enable = lib.mkEnableOption "room server nas";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace} = {
+      room.server = mkDefaultEnabled;
+
+      cli-apps = {
+        tool = {
+          useful = mkDefaultEnabled;
+        };
+        disk = mkDefaultEnabled;
+      };
+    };
+  };
+}

--- a/modules/nixos/room/server/nas/default.nix
+++ b/modules/nixos/room/server/nas/default.nix
@@ -1,0 +1,106 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types mkDefault;
+  inherit (lib.${namespace}.module) mkDefaultEnabled;
+
+  cfg = config.${namespace}.room.server.nas;
+
+  mkServiceOption =
+    desc:
+    mkOption {
+      type = types.bool;
+      default = true;
+      description = desc;
+    };
+in
+{
+  options.${namespace}.room.server.nas = {
+    enable = lib.mkEnableOption "room server nas";
+
+    samba = {
+      enable = mkServiceOption "samba server";
+    };
+    avahi = {
+      enable = mkServiceOption "avahi mDNS";
+    };
+    zfs = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "zfs file system. Requires `networking.hostId` to be set.";
+      };
+    };
+    samba-wsdd = {
+      enable = mkServiceOption "samba wsdd";
+    };
+    sanoid = {
+      enable = mkServiceOption "sanoid zfs snapshot";
+    };
+    beszel = {
+      enable = mkServiceOption "beszel monitoring";
+      hub.enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "beszel hub (web dashboard). Set false if running hub in Docker.";
+      };
+      agent.enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "beszel agent (data collector). Set false if running agent in Docker.";
+      };
+    };
+    netdata = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "netdata monitoring. Heavy, conflicts with beszel.";
+      };
+    };
+    target = {
+      enable = mkServiceOption "target iscsi";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace} = {
+      room.server = mkDefaultEnabled;
+
+      services = {
+        samba = lib.mkIf cfg.samba.enable {
+          enable = mkDefault true;
+          openFirewall = mkDefault true;
+        };
+        avahi = lib.mkIf cfg.avahi.enable {
+          enable = mkDefault true;
+          openFirewall = mkDefault true;
+        };
+        samba-wsdd = lib.mkIf cfg.samba-wsdd.enable {
+          enable = mkDefault true;
+          openFirewall = mkDefault true;
+        };
+        sanoid = lib.mkIf cfg.sanoid.enable mkDefaultEnabled;
+        beszel = lib.mkIf cfg.beszel.enable {
+          enable = mkDefault true;
+          openFirewall = mkDefault true;
+          hub.enable = mkDefault cfg.beszel.hub.enable;
+          agent.enable = mkDefault cfg.beszel.agent.enable;
+        };
+        netdata = lib.mkIf cfg.netdata.enable mkDefaultEnabled;
+        target = lib.mkIf cfg.target.enable {
+          enable = mkDefault true;
+          openFirewall = mkDefault true;
+        };
+      };
+
+      system.fileSystems.zfs = lib.mkIf cfg.zfs.enable mkDefaultEnabled;
+    };
+
+    # disable sudo password
+    security.sudo.wheelNeedsPassword = false;
+  };
+}

--- a/modules/nixos/services/avahi/default.nix
+++ b/modules/nixos/services/avahi/default.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.avahi;
+in
+{
+  options.${namespace}.services.avahi = with types; {
+    enable = lib.mkEnableOption "avahi mDNS";
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Open Avahi mDNS port (UDP 5353) in the firewall.";
+    };
+    publish = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Whether to publish local services via Avahi.";
+      };
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.avahi NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.avahi = {
+      enable = true;
+      inherit (cfg) openFirewall publish;
+    }
+    // cfg.extraOptions;
+  };
+}

--- a/modules/nixos/services/beszel/default.nix
+++ b/modules/nixos/services/beszel/default.nix
@@ -1,0 +1,91 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.beszel;
+
+  envPath =
+    let
+      files = builtins.attrNames cfg.secrets.etc.files;
+    in
+    if files != [ ] then "/etc/${builtins.head files}" else null;
+in
+{
+  options.${namespace}.services.beszel = with types; {
+    enable = lib.mkEnableOption "beszel monitoring";
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Open beszel hub port (TCP 8090 by default) in the firewall.";
+    };
+    hub = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable beszel hub (web dashboard). Set to false if running hub in Docker.";
+      };
+      host = mkOption {
+        type = str;
+        default = "127.0.0.1";
+        description = "Host address for the beszel hub web UI.";
+      };
+      port = mkOption {
+        type = port;
+        default = 8090;
+        description = "Port for the beszel hub web UI.";
+      };
+    };
+    agent = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable beszel agent (data collector). Set to false if running agent in Docker.";
+      };
+      environmentFile = mkOption {
+        type = nullOr path;
+        default = null;
+        description = "Path to environment file for the beszel agent. Defaults to /etc/beszel/env/agent.env when secrets are enabled.";
+      };
+      smartmon.enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable S.M.A.R.T. disk monitoring in beszel agent.";
+      };
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra options merged at services.beszel level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf (cfg.openFirewall && cfg.hub.enable) {
+      allowedTCPPorts = [ cfg.hub.port ];
+    };
+
+    services.beszel = {
+      hub = {
+        enable = cfg.hub.enable;
+        inherit (cfg.hub) host port;
+      };
+      agent = {
+        enable = cfg.agent.enable;
+        smartmon.enable = cfg.agent.smartmon.enable;
+        environmentFile =
+          if cfg.agent.environmentFile != null then
+            cfg.agent.environmentFile
+          else if cfg.secrets.enable then
+            envPath
+          else
+            null;
+      };
+    }
+    // cfg.extraOptions;
+  };
+}

--- a/modules/nixos/services/beszel/secrets/default.nix
+++ b/modules/nixos/services/beszel/secrets/default.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  namespace,
+  purr ? { },
+  ...
+}:
+let
+  host = purr.host or purr.name or "localhost";
+  inherit (lib.${namespace}.secrets) mkAppSecretsOption;
+  inherit (config.${namespace}.secrets) files;
+
+  cfgParent = config.${namespace}.services.beszel;
+  cfg = cfgParent.secrets;
+in
+{
+  options.${namespace}.services.beszel.secrets = mkAppSecretsOption {
+    enable = cfgParent.enable && cfgParent.agent.enable && config.${namespace}.secrets.enable;
+    appName = "beszel";
+    dirPath = "beszel/env";
+    fixedConfig = [
+      {
+        name = "agentKey";
+        fileName = "agent.env";
+      }
+    ];
+    scope = "hosts-global";
+    currentInfo = {
+      inherit host;
+      user = config.${namespace}.user.name;
+    };
+    buildTargetPath = name: files.${name}.path;
+    owner = "root";
+    mode = "0400";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace}.secrets = cfg.secretMappingFiles;
+    environment.etc = lib.mkIf cfg.etc.enable cfg.etc.files;
+  };
+}

--- a/modules/nixos/services/netdata/default.nix
+++ b/modules/nixos/services/netdata/default.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.netdata;
+in
+{
+  options.${namespace}.services.netdata = with types; {
+    enable = lib.mkEnableOption "netdata monitoring";
+    config = mkOption {
+      type = attrs;
+      default = { };
+      description = "Netdata configuration merged at services.netdata.config.";
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.netdata NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.netdata = {
+      enable = true;
+      inherit (cfg) config;
+    }
+    // cfg.extraOptions;
+  };
+}

--- a/modules/nixos/services/samba-wsdd/default.nix
+++ b/modules/nixos/services/samba-wsdd/default.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.samba-wsdd;
+in
+{
+  options.${namespace}.services.samba-wsdd = with types; {
+    enable = lib.mkEnableOption "samba wsdd";
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Open WSDD ports (TCP 5357, UDP 3702) in the firewall for Windows network discovery.";
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.samba-wsdd NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.samba-wsdd = {
+      enable = true;
+      inherit (cfg) openFirewall;
+    }
+    // cfg.extraOptions;
+  };
+}

--- a/modules/nixos/services/samba/default.nix
+++ b/modules/nixos/services/samba/default.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types optionalAttrs;
+
+  cfg = config.${namespace}.services.samba;
+in
+{
+  options.${namespace}.services.samba = with types; {
+    enable = lib.mkEnableOption "samba server";
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Open Samba ports (TCP 139, 445) in the firewall.";
+    };
+    useWizard = lib.mkEnableOption "samba use host config";
+    configFile = {
+      settingsPath = mkOption {
+        type = path;
+        default = "/etc/samba/smb.conf";
+        description = "Path to the Samba smb.conf configuration file.";
+      };
+    };
+    settings = mkOption {
+      type = attrs;
+      default = { };
+      description = "Samba smb.conf settings merged at services.samba.settings.";
+    };
+    persistence = lib.mkEnableOption "add files and directories to impermanence" // {
+      default = true;
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.samba NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.samba = {
+      enable = true;
+      inherit (cfg) openFirewall;
+    }
+    // optionalAttrs (!cfg.useWizard) {
+      inherit (cfg) settings;
+    }
+    // cfg.extraOptions;
+
+    ${namespace}.system.impermanence = lib.mkIf (!cfg.useWizard && cfg.persistence) {
+      directories = [
+        "/etc/samba"
+      ];
+    };
+  };
+}

--- a/modules/nixos/services/samba/secrets/default.nix
+++ b/modules/nixos/services/samba/secrets/default.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  namespace,
+  purr ? { },
+  ...
+}:
+let
+  host = purr.host or purr.name or "localhost";
+  inherit (lib) optional;
+  inherit (lib.${namespace}.secrets) mkAppSecretsOption;
+  inherit (config.${namespace}.secrets) files;
+
+  cfgParent = config.${namespace}.services.samba;
+  cfg = cfgParent.secrets;
+in
+{
+  options.${namespace}.services.samba.secrets = mkAppSecretsOption {
+    enable = cfgParent.enable && config.${namespace}.secrets.enable;
+    appName = "samba";
+    dirPath = "samba";
+    fixedConfig = optional cfgParent.useWizard {
+      name = "smbConf";
+      fileName = "smb.conf";
+    };
+    scope = "hosts-global";
+    currentInfo = {
+      inherit host;
+      user = config.${namespace}.user.name;
+    };
+    buildTargetPath = name: files.${name}.path;
+    owner = "root";
+    mode = "0440";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace}.secrets = cfg.secretMappingFiles;
+    environment.etc = lib.mkIf cfg.etc.enable (lib.mapAttrs (_: lib.mkForce) cfg.etc.files);
+  };
+}

--- a/modules/nixos/services/sanoid/default.nix
+++ b/modules/nixos/services/sanoid/default.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.sanoid;
+in
+{
+  options.${namespace}.services.sanoid = with types; {
+    enable = lib.mkEnableOption "sanoid zfs snapshot";
+    useWizard = lib.mkEnableOption "sanoid use host config";
+    configFile = {
+      settingsPath = mkOption {
+        type = path;
+        default = "/etc/sanoid/sanoid.conf";
+        description = "Path to the Sanoid configuration file.";
+      };
+    };
+    templates = mkOption {
+      type = attrs;
+      default = { };
+      description = "Sanoid snapshot templates.";
+    };
+    datasets = mkOption {
+      type = attrs;
+      default = { };
+      description = "Sanoid dataset configurations.";
+    };
+    interval = mkOption {
+      type = str;
+      default = "hourly";
+      example = "daily";
+      description = ''
+        Run sanoid at this interval (systemd.time format).
+        The default is to run hourly.
+      '';
+    };
+    extraArgs = mkOption {
+      type = listOf str;
+      default = [ ];
+      example = [
+        "--verbose"
+        "--debug"
+      ];
+      description = "Extra arguments passed to the sanoid command.";
+    };
+    persistence = lib.mkEnableOption "add files and directories to impermanence" // {
+      default = true;
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.sanoid NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.sanoid = {
+      enable = true;
+      inherit (cfg)
+        interval
+        extraArgs
+        templates
+        datasets
+        ;
+    }
+    // cfg.extraOptions;
+
+    ${namespace}.system.impermanence = lib.mkIf (!cfg.useWizard && cfg.persistence) {
+      directories = [
+        "/etc/sanoid"
+      ];
+    };
+  };
+}

--- a/modules/nixos/services/sanoid/secrets/default.nix
+++ b/modules/nixos/services/sanoid/secrets/default.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  namespace,
+  purr ? { },
+  ...
+}:
+let
+  host = purr.host or purr.name or "localhost";
+  inherit (lib) optional;
+  inherit (lib.${namespace}.secrets) mkAppSecretsOption;
+  inherit (config.${namespace}.secrets) files;
+
+  cfgParent = config.${namespace}.services.sanoid;
+  cfg = cfgParent.secrets;
+in
+{
+  options.${namespace}.services.sanoid.secrets = mkAppSecretsOption {
+    enable = cfgParent.enable && config.${namespace}.secrets.enable;
+    appName = "sanoid";
+    dirPath = "sanoid";
+    fixedConfig = optional cfgParent.useWizard {
+      name = "sanoidConf";
+      fileName = "sanoid.conf";
+    };
+    scope = "hosts-global";
+    currentInfo = {
+      inherit host;
+      user = config.${namespace}.user.name;
+    };
+    buildTargetPath = name: files.${name}.path;
+    owner = "root";
+    mode = "0444";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace}.secrets = cfg.secretMappingFiles;
+    environment.etc = lib.mkIf cfg.etc.enable (lib.mapAttrs (_: lib.mkForce) cfg.etc.files);
+  };
+}

--- a/modules/nixos/services/target/default.nix
+++ b/modules/nixos/services/target/default.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.services.target;
+in
+{
+  options.${namespace}.services.target = with types; {
+    enable = lib.mkEnableOption "target iscsi lio";
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Open iSCSI port (TCP 3260) in the firewall.";
+    };
+    useWizard = lib.mkEnableOption "target use host config";
+    configFile = {
+      enable = lib.mkEnableOption "target config file";
+      settingsPath = mkOption {
+        type = path;
+        default = "/etc/target/saveconfig.json";
+        description = "Path to the LIO target configuration file.";
+      };
+    };
+    persistence = lib.mkEnableOption "add files and directories to impermanence" // {
+      default = true;
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra services.target NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.target = {
+      enable = true;
+    }
+    // cfg.extraOptions;
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 3260 ];
+    };
+
+    ${namespace}.system.impermanence = lib.mkIf (!cfg.useWizard && cfg.persistence) {
+      directories = [
+        "/etc/target"
+      ];
+    };
+  };
+}

--- a/modules/nixos/services/target/secrets/default.nix
+++ b/modules/nixos/services/target/secrets/default.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  namespace,
+  purr ? { },
+  ...
+}:
+let
+  host = purr.host or purr.name or "localhost";
+  inherit (lib) optional;
+  inherit (lib.${namespace}.secrets) mkAppSecretsOption;
+  inherit (config.${namespace}.secrets) files;
+
+  cfgParent = config.${namespace}.services.target;
+  cfg = cfgParent.secrets;
+in
+{
+  options.${namespace}.services.target.secrets = mkAppSecretsOption {
+    enable = cfgParent.enable && config.${namespace}.secrets.enable;
+    appName = "target";
+    dirPath = "target";
+    fixedConfig = optional cfgParent.useWizard {
+      name = "config";
+      fileName = "saveconfig.json";
+    };
+    scope = "hosts-global";
+    currentInfo = {
+      inherit host;
+      user = config.${namespace}.user.name;
+    };
+    buildTargetPath = name: files.${name}.path;
+    owner = "root";
+    mode = "0400";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ${namespace}.secrets = cfg.secretMappingFiles;
+    environment.etc = lib.mkIf cfg.etc.enable (lib.mapAttrs (_: lib.mkForce) cfg.etc.files);
+  };
+}

--- a/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
+++ b/modules/nixos/system/fileSystems/btrfs/impermanence/default.nix
@@ -26,12 +26,12 @@ in
             };
             tempDir = mkOption {
               type = str;
-              default = "/btrfs_''${config.subvol}_tmp";
+              default = "/btrfs_${config.subvol}_tmp";
               description = "Temporary mount directory used during the BTRFS rollback process.";
             };
             oldSubvolDir = mkOption {
               type = str;
-              default = "old_''${config.subvol}";
+              default = "old_${config.subvol}";
               description = "Directory name where old snapshot subvolumes are archived.";
             };
             subvol = mkOption {

--- a/modules/nixos/system/fileSystems/zfs/default.nix
+++ b/modules/nixos/system/fileSystems/zfs/default.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.${namespace}.system.fileSystems.zfs;
+in
+{
+  options.${namespace}.system.fileSystems.zfs = with types; {
+    enable = lib.mkEnableOption "zfs file system. Requires `networking.hostId` to be set";
+    autoScrub = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable periodic ZFS pool scrubbing.";
+      };
+      interval = mkOption {
+        type = str;
+        default = "weekly";
+        description = "ZFS scrub interval (weekly, monthly, etc.).";
+      };
+    };
+    autoSnapshot = {
+      enable = mkOption {
+        type = bool;
+        default = false;
+        description = "Enable automatic ZFS snapshots.";
+      };
+    };
+    trim = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Enable periodic TRIM for SSDs in ZFS pools.";
+      };
+      interval = mkOption {
+        type = str;
+        default = "weekly";
+        description = "ZFS TRIM interval (weekly, monthly, etc.).";
+      };
+    };
+    persistence = lib.mkEnableOption "add files and directories to impermanence" // {
+      default = true;
+    };
+    extraOptions = mkOption {
+      type = attrs;
+      default = { };
+      description = "Extra ZFS NixOS options merged at top level.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.supportedFilesystems = [ "zfs" ];
+
+    services.zfs = {
+      autoScrub = lib.mkIf cfg.autoScrub.enable {
+        inherit (cfg.autoScrub) enable interval;
+      };
+      autoSnapshot = lib.mkIf cfg.autoSnapshot.enable {
+        enable = true;
+      };
+      trim = lib.mkIf cfg.trim.enable {
+        inherit (cfg.trim) enable interval;
+      };
+    }
+    // cfg.extraOptions;
+
+    ${namespace}.system.impermanence = lib.mkIf cfg.persistence {
+      directories = [
+        "/etc/zfs"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
New NAS room module enables common storage services with sensible defaults:

## Services included
- **samba** (with secrets), **samba-wsdd**, **nfs**, **avahi** for file sharing
- **target** (iSCSI LIO with secrets) for block storage
- **sanoid** (with secrets) for ZFS snapshots
- **beszel** (with secrets + firewall) for monitoring
- **netdata** for alternative monitoring
- **zfs** file system support

## Features
- Firewall auto-open for target, samba, nfs, avahi, samba-wsdd, beszel when in NAS room
- Secrets integration via agenix for samba, sanoid, target, beszel
- All enable/disable toggles at room level