### PR TITLE
fix(samba): remove unnecessary escaped quotes in secretsPath interpolation

### DIFF
--- a/modules/nixos/system/fileSystems/samba/default.nix
+++ b/modules/nixos/system/fileSystems/samba/default.nix
@@ -62,7 +62,7 @@ let
         };
         secretsPath = mkOption {
           type = path;
-          default = "/etc/samba/secrets/''${sambaName}.conf";
+          default = "/etc/samba/secrets/${sambaName}.conf";
           description = "Path to the credentials file for this Samba share.";
         };
         extraOptions = mkOption {


### PR DESCRIPTION
In , the extra single quotes around the interpolation are unnecessary - just  is sufficient and consistent with Nix conventions.