### PR TITLE
fix: keep proxmox-lxc image variant buildable

### DIFF
--- a/modules/nixos/system/proxmox/lxc/default.nix
+++ b/modules/nixos/system/proxmox/lxc/default.nix
@@ -39,6 +39,14 @@ in
     proxmoxLXC = {
       inherit (cfg) enable manageNetwork manageHostName;
     };
+
+    # The `proxmox-lxc` image variant (`system.build.images.proxmox-lxc`)
+    # inherits the `proxmoxLXC.enable = false` definition above, which would
+    # disable it. Only force it on when the feature is not enabled on the
+    # host, so an LXC image can still be built for image-only hosts.
+    image.modules.proxmox-lxc = {
+      proxmoxLXC.enable = lib.mkIf (!cfg.enable) (lib.mkForce true);
+    };
   };
 
 }


### PR DESCRIPTION
## What

The `proxmox/lxc` module imports `proxmox-lxc.nix` at the toplevel and sets `proxmoxLXC.enable = cfg.enable` (false by default) on every host. That definition is inherited by every `extendModules`-based image variant, so `system.build.images.proxmox-lxc` could never be built (missing required `system.build.image`).

This PR overrides the `proxmox-lxc` image variant to force `proxmoxLXC.enable` on **only when the feature is not enabled on the host**, so image-only hosts can still build the LXC tarball while hosts that enable the feature are untouched (no redundant definition).

## Test

`nix flake check` passes on cattery-modules.

## Checklist

- [x] `nix flake check` green
- [x] formatted with nixfmt