### PR TITLE
feat(user): add injectHomeUser option and macOS home directory

### DIFF
--- a/modules/home/user/default.nix
+++ b/modules/home/user/default.nix
@@ -9,6 +9,8 @@ let
   inherit (pkgs.stdenv.hostPlatform) isLinux;
   inherit (lib)
     mkDefault
+    mkIf
+    mkMerge
     mkOption
     types
     optionalAttrs
@@ -22,6 +24,16 @@ in
 {
   options.${namespace}.user = with types; {
     addToAccounts = lib.mkEnableOption "add user to home accounts";
+    injectHomeUser = mkOption {
+      type = bool;
+      default = cfg.settings.injectHomeUser or true;
+      description = ''
+        Whether to inject the user into home-manager by setting
+        `home.username` and `home.homeDirectory`. Disable this when the
+        surrounding flake framework (e.g. purr) already injects the user.
+        Can also be controlled via `settings.injectHomeUser`.
+      '';
+    };
     name = mkOption {
       type = str;
       default = cfg.settings.name or "nixos";
@@ -139,35 +151,38 @@ in
     };
   };
 
-  config = {
-    home = {
-      username = mkDefault name;
-      homeDirectory = mkDefault home;
-    };
+  config = mkMerge [
+    (mkIf cfg.injectHomeUser {
+      home = {
+        username = mkDefault name;
+        homeDirectory = mkDefault home;
+      };
+    })
 
-    # add user to home accounts
-    accounts.email.accounts = lib.mkIf cfg.addToAccounts {
-      ${name} = {
-        inherit (cfg) realName;
-        inherit (cfg.email) address userName imap;
-        primary = mkDefault true;
-        smtp =
-          if cfg.email.smtp != null then
-            {
-              inherit (cfg.email.smtp) host port;
-              tls = optionalAttrs (cfg.email.smtp.port == 587) {
-                enable = true;
-                useStartTls = true;
-              };
-            }
-          else
-            null;
-        gpg = optionalAttrs (cfg.gpg.encryptKey != null) {
-          key = cfg.gpg.encryptKey;
-          signByDefault = true;
+    {
+      # add user to home accounts
+      accounts.email.accounts = lib.mkIf cfg.addToAccounts {
+        ${name} = {
+          inherit (cfg) realName;
+          inherit (cfg.email) address userName imap;
+          primary = mkDefault true;
+          smtp =
+            if cfg.email.smtp != null then
+              {
+                inherit (cfg.email.smtp) host port;
+                tls = optionalAttrs (cfg.email.smtp.port == 587) {
+                  enable = true;
+                  useStartTls = true;
+                };
+              }
+            else
+              null;
+          gpg = optionalAttrs (cfg.gpg.encryptKey != null) {
+            key = cfg.gpg.encryptKey;
+            signByDefault = true;
+          };
         };
       };
-    };
-
-  };
+    }
+  ];
 }

--- a/modules/shared/user/default.nix
+++ b/modules/shared/user/default.nix
@@ -202,6 +202,9 @@ in
       users.users.${cfg.name} = {
         # Just to ensure that it is not null when accessing, the default value on Mac is 501
         uid = 501;
+        # macOS root lives outside /Users; everyone else under /Users/<name>.
+        # home-manager reads `users.users.<name>.home` for `home.homeDirectory`.
+        home = if cfg.name == "root" then "/var/root" else "/Users/${cfg.name}";
         openssh.authorizedKeys = cfg.authorizedKeys;
         shell = cfg.defaultUserShell;
       };


### PR DESCRIPTION
## What

- **home/user**: add an `injectHomeUser` option (default `cfg.settings.injectHomeUser or true`) that controls whether the module injects the user into home-manager via `home.username` / `home.homeDirectory`. Disable it when the surrounding flake framework (e.g. purr) already injects the user.
- **shared/user**: set `users.users.<name>.home` on macOS (\`/Users/<name>\`, or \`/var/root\` for root) so home-manager reads the correct `home.homeDirectory`.

## Test

`nix flake check` is run by CI.

## Checklist

- [x] formatted with nixfmt
- [x] deadnix/statix clean (pre-commit passed)